### PR TITLE
Add Agenda Hero to productivity list

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -51,6 +51,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 ### Productivity
 
 - [Ready to Send](Ready to Send) - Auto-generated draft email replies for Gmail.
+- [Agenda Hero](https://agendahero.com) - Generate beautiful, structured, shareable schedules with AI.
 
 ### Meeting assistants
 


### PR DESCRIPTION
Adds [Agenda Hero](https://agendahero.com) to the productivity discoveries list.