### PR TITLE
Adding openlit to developer tools in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Cursor](https://www.cursor.so/) - Cursor is the IDE of the future, built for pair-programming with Powerful AI.
 - [SymbolicAI](https://github.com/Xpitfire/symbolicai) - A neuro-symbolic framework for building applications with LLMs at the core.
 - [Ollama](https://github.com/ollama/ollama) - Get up and running with large language models locally.
+- [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics.
 
 ## Agents
 


### PR DESCRIPTION
Adding OpenLIT to developer tools section.

Brief introduction about OpenLIT :
OpenLIT is an OpenTelemetry-native GenAI and LLM Application Observability tool. It's designed to make the integration process of observability into GenAI projects as easy as pie – literally, with just a single line of code. 
To explore more checkout https://github.com/openlit/openlit