### PR TITLE
Add Typist to Speech-to-text section

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -216,6 +216,8 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 ### Speech-to-text
 
+- [Typist](https://iamtypist.dev) - Fast audio transcription service powered by Whisper models hosted on Groq.
+
 ### Music
 - [Boomy](https://boomy.com/) - Create original songs in seconds.
 - [Soundraw](https://soundraw.io/) - Create your beats with the power of AI.


### PR DESCRIPTION
 Hey Steven :) I've stumbled upon this repo while searching for alternatives to my own tool and decided to list since I didn't find any.

Opened a PR to add Typist to the Speech-to-text section in DISCOVERIES.md.


Typist is a lightning-fast AI audio & video transcription service built on top of latest Whisper models hosted on Groq.

What makes it different:
**Speed:** 1-hour audio → transcript in <20 seconds (40x faster than typical whisper-v2, 216x faster than real-time) 
**Accuracy:** ~10-20% fewer errors than whisper-v2 
**UX:** Synced playback with follow-along highlighting. Export to DOCX, PDF, TXT, and SRT formats.
**Free tier:** I've built this to solve my own pain point as well as for anyone who needs reliable and fast transcription, for example students. Typist has a generous free-tier available for all, no credit card required.

