### PR TITLE
Add promptfoo to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource
+- [promptfoo](https://github.com/promptfoo/promptfoo) - Test and evaluate LLM applications. Compare prompts, models, and RAG systems. Red team with adversarial attacks. CI/CD integration. #opensource
 
 ### Playgrounds
 - [OpenAI Playground](https://platform.openai.com/playground) - Explore resources, tutorials, API docs, and dynamic examples.


### PR DESCRIPTION
## Summary

Added [promptfoo](https://github.com/promptfoo/promptfoo) to the Developer tools section.

promptfoo is an open-source tool for testing and evaluating LLM applications. It helps developers compare prompts and models, test RAG architectures, and catch regressions and security vulnerabilities with CI/CD integration.

Fits well alongside other developer tools like agenta, Phoenix, and OpenLIT.

Thanks for maintaining this list!