### PR TITLE
Add rehydra SDK to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Opik](https://github.com/comet-ml/opik) - An open-source platform for tracing, evaluating, and monitoring LLM applications. [#opensource](https://github.com/comet-ml/opik)
 - [Langfuse](https://langfuse.com/) - An open-source LLM engineering platform for tracing, evaluation, prompt management, and metrics. [#opensource](https://github.com/langfuse/langfuse)
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
+- [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 
 ### Playgrounds
 


### PR DESCRIPTION
## Summary
Adding `rehydra` to the Developer Tools section.

About `rehydra`
**What**: A zero-trust privacy SDK for LLMs.

**How**: It allows developers to anonymize PII locally (using Regex/NER) before sending them to the provider, and then seamlessly "rehydrating" the (streaming) response to restore the original context.

**Why**: It solves the data sovereignty problem, allowing developers to use public models (like GPT-5.2) with sensitive client data without any PII leaving their infrastructure.

## Links
GitHub: https://github.com/rehydra-ai/rehydra-sdk

npm: https://www.npmjs.com/package/rehydra