### PR TITLE
Add Price Per Token to Leaderboards section

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -99,6 +99,8 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 ### Leaderboards
 
+- [Price Per Token](https://pricepertoken.com/) - A tool for comparing LLM API pricing, token usage, and model benchmarks.
+
 ### Other text generators
 
 - [Never Jobless](https://neverjobless.com/) - Maximize your interview chances with AI-powered LinkedIn messaging.


### PR DESCRIPTION
Adding Price Per Token (https://pricepertoken.com) to the Leaderboards section.

**Why this addition is valuable:**
- Compare LLM API pricing across 200+ models
- Token counters and cost calculators
- Benchmark comparisons included
- Free to use