### PR TITLE
docs: add AI Detect Lab to image services

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Flux](https://github.com/black-forest-labs/flux) - Text-to-image models by Black Forest Labs with high-quality photorealistic output. #opensource
 
 ### Services
-
+- [AI Detect Lab](https://www.aidetectlab.com/) - Professional AI image detector for Midjourney v7 and Flux.
 - [Craiyon](https://www.craiyon.com/) - Craiyon, formerly DALL-E mini, is an AI model that can draw images from any text prompt.
 - [DreamStudio](https://beta.dreamstudio.ai/) - DreamStudio is an easy-to-use interface for creating images using the Stable Diffusion image generation model.
 - [Artbreeder](https://www.artbreeder.com/) - Artbreeder is new type of creative tool that empowers users creativity by making it easier to collaborate and explore.


### PR DESCRIPTION
## Summary
Added **AI Detect Lab** to the Services (Image) section.

## Why this is a good addition?
AI Detect Lab is a professional-grade, 100% free AI image and deepfake detector optimized for 2026 models like Midjourney v7 and Flux 2 with a verified 99.2% accuracy rate. It provides essential forensics tools for the generative AI community.