### PR TITLE
Add MaxVideoAI to Video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Hailuo AI](https://hailuoai.video/) - AI-powered text-to-video generator.
 - [Google Flow](https://flow.google) - An AI filmmaking tool from Google, powered by Veo.
 - [Seedance 2.0](https://seed.bytedance.com/en/seedance2_0) - An image-to-video and text-to-video model developed by Niobotics ByteDance.
+- [MaxVideoAI](https://maxvideoai.com/examples) - A workspace for generating and comparing videos across multiple AI video models.
 
 ### Avatars
 


### PR DESCRIPTION
Adds MaxVideoAI to the Video section.
The linked page is public and showcases practical video generation examples across multiple AI video models.
