### PR TITLE
Add Standards SDK - TypeScript SDK for AI agents on Hedera

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource
+- [Standards SDK](https://hol.org/) - A TypeScript SDK for building AI agents on Hedera with decentralized messaging, state management, and plugin system. [#opensource](https://github.com/hashgraph-online/standards-sdk)
 
 ### Playgrounds
 - [OpenAI Playground](https://platform.openai.com/playground) - Explore resources, tutorials, API docs, and dynamic examples.


### PR DESCRIPTION
Adding Standards SDK to the Developer tools section.

Standards SDK is an open-source TypeScript framework for building AI agents on the Hedera network.

- GitHub: https://github.com/hashgraph-online/standards-sdk
- NPM: @hashgraphonline/standards-sdk