### PR TITLE
Add Agentset to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Langfuse](https://langfuse.com/) - An open-source LLM engineering platform for tracing, evaluation, prompt management, and metrics. [#opensource](https://github.com/langfuse/langfuse)
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
+- [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
 
 ### Playgrounds
 


### PR DESCRIPTION
This PR adds Agentset to the **Developer tools** section under **Coding**.

[Agentset](https://agentset.ai) is an open-source platform to build, evaluate, and ship production-ready RAG and agentic applications with end-to-end tooling: ingestion, vector indexing, evaluation, chat playground, hosting, and developer API.

**Why it fits:**
- Similar to existing tools like LlamaIndex, Vanna.ai, and agenta in this section
- Open-source RAG/LLM application framework
- Production-ready with active maintenance

**Checklist:**
- [x] Follows format: `[ProjectName](Link) - Description.`
- [x] Added to bottom of Developer tools section
- [x] Description is concise and ends with a period
- [x] Includes #opensource tag with GitHub link
- [x] Link verified and working