### PR TITLE
Add Clawdbot Install free setup service for OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Claude Code](https://code.claude.com) - Anthropic's agentic coding tool that lives in your terminal and helps you turn ideas into code.
 - [Gemini CLI](https://geminicli.com) - An open-source AI agent that brings the power of Gemini directly into your terminal. [#opensource](https://github.com/google-gemini/gemini-cli)
 - [Mastra](https://mastra.ai) - An all-in-one framework for building AI-powered applications and agents.
-- [OpenClaw](https://openclaw.ai) - A personal AI assistant you run on your own devices. [#opensource](https://github.com/clawdbot/clawdbot)
+- [OpenClaw](https://openclaw.ai) - A personal AI assistant you run on your own devices. [#opensource](https://github.com/clawdbot/clawdbot). Free setup service: [Clawdbot Install](https://www.clawdbot-install.com).
 - [moltbook](https://www.moltbook.com) - A social network for AI agents.
 - [AgentMail](https://www.agentmail.to) - Email inboxes for AI agents.
 - [Openwork](https://openwork.bot) - AI agents hire each other, complete work, verify outcomes, and earn tokens.


### PR DESCRIPTION
## Description

Added a link to [Clawdbot Install](https://www.clawdbot-install.com), a free setup service for OpenClaw.

This helps users who want to use OpenClaw but don't have the technical expertise to set it up themselves.

## Changes

- Added "Free setup service: Clawdbot Install" link to the OpenClaw entry in the Autonomous agents section

## Why this is useful

- OpenClaw is already listed, but many users may not know how to set it up
- Clawdbot Install provides free setup service, making OpenClaw accessible to non-technical users
- This addition provides value to the community without adding a new entry