### PR TITLE
Add pm-skills to Discoveries Autonomous Agents

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -131,6 +131,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [BrainSoup](https://www.nurgo-software.com/products/brainsoup) Versatile multi-LLM & multi-agent client with RAG, multi-modality, automation, code interpreter, sandboxed file system and more.
 - [Maestro](https://runmaestro.ai) - Run multiple AI coding agents in parallel with a spec-driven workflow. [#opensource](https://github.com/pedramamini/Maestro)
 - [Maxim AI](https://www.getmaxim.ai) - An enterprise-grade generative AI evaluation and observability platform.
+- [pm-skills](https://github.com/product-on-purpose/pm-skills) - An open-source library of 24 product management agent skills spanning the full product lifecycle. [#opensource](https://github.com/product-on-purpose/pm-skills)
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds pm-skills to the Discoveries list (Agents > Autonomous agents).

pm-skills is an open-source (Apache 2.0) library of 24 structured product
management skills for AI agents, covering discovery through delivery.
It follows the agentskills.io specification.