### PR TITLE
Add Frontman to Discoveries - Coding Assistants

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -121,6 +121,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Keploy](https://keploy.io) - Open-source AI testing agent for generating API, integration, and end-to-end tests. [#opensource](https://github.com/keploy/keploy)
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - CLI tool that translates natural-language prompts into shell commands and asks for confirmation before execution.
 - [Yume](https://github.com/aofp/yume) - Desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, and plugin system. #opensource
+- [Frontman](https://frontman.sh/) - A browser-based AI coding agent for editing frontend code with live app context. [#opensource](https://github.com/frontman-ai/frontman)
 
 ### Developer tools
 


### PR DESCRIPTION
## Add Frontman

[Frontman](https://github.com/frontman-ai/frontman) is an open-source AI coding agent that lives in your browser. Unlike Cursor/Copilot which work blind to the UI, Frontman hooks into your dev server as middleware and sees the live DOM, component tree, styles, and routes.

Click any element, describe changes in plain English, and get real source code edits with hot reload. Supports Next.js, Vite (React, Vue, Svelte), and Astro.

Added to the **Discoveries > Coding > Coding Assistants** section.

Note: Frontman has ~121 GitHub stars so is suited for the Discoveries list rather than the main list. Happy to adjust if the maintainer prefers a different placement.

https://github.com/frontman-ai/frontman