### PR TITLE
Add Mantra to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource
+- [Mantra](https://mantra.gonewx.com) - Local-first session time-machine for AI coding tools (Claude Code, Cursor, Windsurf). Snapshot, browse, diff, and restore any past session state. [#opensource](https://github.com/mantra-hq/mantra-releases)
 
 ### Playgrounds
 - [OpenAI Playground](https://platform.openai.com/playground) - Explore resources, tutorials, API docs, and dynamic examples.


### PR DESCRIPTION
## Summary

- Adds [Mantra](https://mantra.gonewx.com) to the **Coding > Developer tools** section
- Mantra is a local-first session time-machine for AI coding tools (Claude Code, Cursor, Gemini CLI, Codex (Windsurf: In Development)). It lets you snapshot, browse, diff, and restore any past session state.
- Public GitHub repo: https://github.com/mantra-hq/mantra-releases

## Format

Entry follows the existing list format with an `[#opensource]` link to the public GitHub releases repo.