### PR TITLE
Add OmniRoute — self-hostable AI gateway with 4-tier fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Meta's LLaMA model (and others) in pure C/C++. #opensource
 - [bitnet.cpp](https://github.com/microsoft/BitNet) - Official inference framework for 1-bit LLMs, by Microsoft. [#opensource](https://github.com/microsoft/BitNet)
 - [OpenRouter](https://openrouter.ai/) - A unified interface for LLMs. [#opensource](https://github.com/OpenRouterTeam)
+- [OmniRoute](https://github.com/diegosouzapw/OmniRoute) - A self-hostable AI gateway with 4-tier cascading fallback, multi-provider load balancing, and OpenAI-compatible API. Supports 200+ models. [#opensource](https://github.com/diegosouzapw/OmniRoute)
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource


### PR DESCRIPTION
## Add OmniRoute

[OmniRoute](https://github.com/diegosouzapw/OmniRoute) is a self-hostable AI gateway with:

- 🔄 **4-tier cascading fallback** — automatic retry across providers
- ⚖️ **Multi-provider load balancing** — distribute requests across OpenAI, Anthropic, Google, local models
- 🔌 **OpenAI-compatible API** — drop-in replacement, works with any OpenAI SDK
- 🎯 **200+ models supported** — GPT, Claude, Gemini, Llama, Mistral, etc.
- 🐳 **Docker-ready** — single `docker compose up` deployment
- 📊 **Dashboard** — real-time monitoring, flow visualization, provider management

**GitHub:** https://github.com/diegosouzapw/OmniRoute
**License:** MIT