### PR TITLE
Add off-grid-mobile: on-device LLM + Stable Diffusion for iOS & Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [LM Studio](https://lmstudio.ai) - Download and run local LLMs on your computer.
 - [RunThisLLM](https://runthisllm.com) - See which LLMs you can run on your hardware.
 - [Harbor](https://github.com/av/harbor) - A containerized toolkit for running local LLM backends, UIs, and supporting services with one command. #opensource
+- [off-grid-mobile](https://github.com/alichherawalla/off-grid-mobile-ai) - React Native app for running LLMs, vision models, and Stable Diffusion on-device on iOS and Android without internet access. [#opensource](https://github.com/alichherawalla/off-grid-mobile-ai)
 
 ## Agents
 


### PR DESCRIPTION
## What

Adds [off-grid-mobile](https://github.com/alichherawalla/off-grid-mobile) to the **Local LLM Deployment** section.

## About the project

off-grid-mobile is an open source React Native app (MIT) that runs LLMs, vision models, and Stable Diffusion fully on-device on iOS and Android. No internet, no cloud API, no data leaves the phone.

- On-device LLM inference (llama.cpp via llm.rn)
- On-device vision/multimodal models  
- On-device text-to-image via Core ML / Stable Diffusion Swift (iOS)
- MIT license, actively maintained

It extends the "local LLM" category to mobile devices — same philosophy as Ollama/Jan/LM Studio but runs on your phone.