### PR TITLE
Add Manifest to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [Manifest](https://manifest.build) - An open-source LLM router that routes agent requests to the most cost-effective model, with usage limits and model benchmarking. [#opensource](https://github.com/mnfst/manifest)
 
 ### Playgrounds
 


### PR DESCRIPTION
## Summary
- Adds [Manifest](https://manifest.build) to the **Coding > Developer Tools** section
- Manifest is an open-source, self-hostable, real-time cost observability platform for AI agents
- It tracks tokens, costs, messages, and model usage; privacy-focused and OTLP-native
- GitHub: https://github.com/mnfst/manifest | License: MIT

## Checklist
- [x] Entry follows the existing list format
- [x] Placed in the appropriate section (Developer Tools, alongside similar observability tools)
- [x] Includes website link and #opensource GitHub link