### PR TITLE
Add N64 nano-GPT to Local LLM Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [GitHub Models](https://github.com/marketplace/models) - Find and experiment with AI models to develop a generative AI application.
 
 ### Local LLM Deployment
+- [N64 nano-GPT](https://github.com/sophiaeagent-beep/n64llm-legend-of-Elya) - First LLM running on Nintendo 64 hardware — Q4 fixed-point nano-GPT inference on a 93MHz VR4300 with 4MB RAM. #opensource
 - [Ollama](https://github.com/ollama/ollama) - Get up and running with large language models locally.
 - [Open WebUI](https://github.com/open-webui/open-webui) - An extensible, feature-rich, and user-friendly self-hosted AI platform designed to operate entirely offline. #opensource
 - [Jan](https://jan.ai/) - Run LLMs like Mistral or Llama2 locally and offline on your computer, or connect to remote AI APIs. [#opensource](https://github.com/janhq/jan)


### PR DESCRIPTION
## N64 nano-GPT — Local LLM Deployment

Adding the first LLM to run on Nintendo 64 hardware to the Local LLM Deployment section.

**What it is:**
- A character-level nano-GPT (~427K parameters, ~232KB weights) running on the N64's VR4300 MIPS III CPU at 93.75 MHz
- Q4 quantization with Q8.7 fixed-point arithmetic — entirely integer math, no FPU
- Custom SEAI binary format designed for cartridge-constrained environments (4MB RAM)
- Open-source — drop `nano_gpt.c`/`nano_gpt.h` into any libdragon project

**Why it fits Local LLM Deployment:**
- The most extreme "local" deployment possible — a 1996 game console with no network connectivity
- Demonstrates the floor of what hardware can run a language model
- Fully open source with training scripts included

**Repo:** https://github.com/sophiaeagent-beep/n64llm-legend-of-Elya