### PR TITLE
Add EvoLink under Video section

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -145,6 +145,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AI/ML API](https://aimlapi.com/) - Unified API for accessing multiple AI models across text, image, audio, and video.
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
+- [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adding [EvoLink](https://evolink.ai) to the Video section. It provides unified API access to multiple video generation models (Seedance 2.0, Sora 2, Veo 3.1, Kling) through a single endpoint.

I found it useful for projects that need to switch between different video models without changing integration code.