### PR TITLE
Add OpenAgents to agent frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Agent Skills](https://agentskills.io) - Open format and reference SDK for packaging reusable capabilities and expertise for AI agents. [#opensource](https://github.com/agentskills/agentskills)
 - [PraisonAI](https://github.com/MervinPraison/PraisonAI) - A framework for building multi-agent AI systems with workflows, tool integrations, and memory. #opensource
 - [Hermes Agent](https://hermes-agent.nousresearch.com) - A self-improving personal agent with memory, messaging integrations, and sandboxed tool execution. [#opensource](https://github.com/NousResearch/hermes-agent)
+- [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
## Summary

- Adds [OpenAgents](https://github.com/openagents-org/openagents) to the **Autonomous agents** section under **Agents**.
- OpenAgents is an open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A).
- Entry follows the existing list format and is tagged with `#opensource`.

## Details

OpenAgents provides a unified platform for creating, deploying, and orchestrating AI agents across multiple communication protocols. It supports WebSocket, gRPC, HTTP, MCP, and A2A, making it a versatile framework for agent-based applications.

Repository: https://github.com/openagents-org/openagents