### PR TITLE
Add CallStack to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Meta's LLaMA model (and others) in pure C/C++. #opensource
 - [bitnet.cpp](https://github.com/microsoft/BitNet) - Official inference framework for 1-bit LLMs, by Microsoft. [#opensource](https://github.com/microsoft/BitNet)
 - [OpenRouter](https://openrouter.ai/) - A unified interface for LLMs. [#opensource](https://github.com/OpenRouterTeam)
+- [CallStack](https://callstack-api.vercel.app/) - Open-source LLM API gateway with multi-provider failover, cost tracking, and caching. One API for OpenAI, Anthropic, Gemini, and DeepSeek. [#opensource](https://github.com/alenmanjgafic/callstack)
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource


### PR DESCRIPTION
## What is CallStack?

[CallStack](https://github.com/alenmanjgafic/callstack) is an open-source LLM API gateway that provides a single, OpenAI-compatible endpoint for OpenAI, Anthropic, Google Gemini, and DeepSeek.

**Key features:**
- Multi-provider automatic failover (4 providers)
- Per-request cost tracking via response headers
- Built-in response caching (5-min TTL)
- SSE streaming support across all providers
- Zero setup — change your base URL and go
- MIT licensed, runs on Vercel Edge Functions

**Why it belongs here:**
Similar tools like OpenRouter and Portkey are already listed in the Developer tools section. CallStack fills the gap as a free, open-source, zero-markup alternative.

- Website: https://callstack-api.vercel.app
- GitHub: https://github.com/alenmanjgafic/callstack
- License: MIT