### PR TITLE
Add OpenPaw — CLI tool that gives Claude Code 38 personal assistant skills

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -174,6 +174,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 - [SiteGPT](https://sitegpt.ai/) - Make AI your expert customer support agent.
 - [Ebiose](https://github.com/ebiose-ai/ebiose) - An open-source framework for creating and evolving AI agents through iterative selection. #opensource
+- [OpenPaw](https://github.com/daxaur/openpaw) - A CLI tool that turns Claude Code into a personal assistant with skills for email, calendar, Spotify, smart home, and Slack. #opensource
 
 ## Image
 


### PR DESCRIPTION
Hey! I'd like to add [OpenPaw](https://github.com/daxaur/openpaw) to the Autonomous agents section.

OpenPaw is an open-source CLI tool (`npx pawmode`) that turns Claude Code into a full personal assistant. It comes with 38 ready-to-use skills covering things like email, calendar, Spotify, smart home control, Slack, GitHub, and more. No daemon, no cloud backend — everything runs locally through Claude. MIT licensed.

- **npm**: https://www.npmjs.com/package/pawmode
- **GitHub**: https://github.com/daxaur/openpaw

I added it to the bottom of the Autonomous agents section, following the contribution guidelines. Let me know if you'd prefer it somewhere else!