### PR TITLE
Add APIClaw - The API layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Meta's LLaMA model (and others) in pure C/C++. #opensource
 - [bitnet.cpp](https://github.com/microsoft/BitNet) - Official inference framework for 1-bit LLMs, by Microsoft. [#opensource](https://github.com/microsoft/BitNet)
 - [OpenRouter](https://openrouter.ai/) - A unified interface for LLMs. [#opensource](https://github.com/OpenRouterTeam)
+- [APIClaw](https://apiclaw.nordsym.com/) - The API layer for AI agents. 22,000+ APIs indexed with semantic discovery and Direct Call execution via MCP. Giving agents access to real-world APIs. Discovery is free forever. [#opensource](https://github.com/nordsym/apiclaw)
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource


### PR DESCRIPTION
Adding APIClaw to the Developer tools section.

## APIClaw
The API layer for AI agents — giving agents access to real-world APIs.

- **22,000+ APIs indexed** — Semantic discovery by capability
- **18 Direct Call providers** — Execute without API keys
- **MCP native** — Works with any MCP-compatible agent
- **Discovery is free forever** — Search, compare, evaluate at no cost

https://github.com/nordsym/apiclaw
https://apiclaw.nordsym.com