### PR TITLE
Add GEOScore to Search engines section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Phind](https://phind.com/) - AI-based search engine.
 - [You.com](https://you.com/) - A search engine built on AI that provides users with a customized search experience while keeping their data 100% private.
 - [Komo](https://komo.ai/) - An AI-powered search engine.
+- [GEOScore](https://geoscoreai.com/) - AI search visibility scanner that checks how your website performs in ChatGPT, Perplexity, and Gemini with 11 technical checks.
 
 ### Local search engines
 


### PR DESCRIPTION
## Summary

- Add [GEOScore](https://geoscoreai.com/) to the **Text > Search engines** section
- GEOScore is an AI search visibility scanner that checks how your website performs in ChatGPT, Perplexity, and Gemini with 11 technical checks

## Why it belongs here

GEOScore fits naturally in the Search engines subsection as it's an AI-powered tool focused on AI search engine visibility and optimization. It helps website owners understand and improve how their content appears across major AI search platforms.