### PR TITLE
Add llm-costs to the list of resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource
+- [llm-costs](https://github.com/followtayeeb/llm-costs) - Compare LLM API costs across 17 models and 6 providers from your terminal. Zero install via npx. #opensource
 
 ### Playgrounds
 - [OpenAI Playground](https://platform.openai.com/playground) - Explore resources, tutorials, API docs, and dynamic examples.


### PR DESCRIPTION
Adds llm-costs to the Developer tools section.

llm-costs is an open-source CLI tool that lets you instantly compare LLM API pricing across 17 models and 6 providers (Anthropic, OpenAI, Google, DeepSeek, Mistral, Cohere) directly from your terminal — zero install required via `npx llm-costs`.

- Real-time cost comparison across providers
- - Auto-updating prices via GitHub Actions
- - Budget guard mode, JSON output, MCP server support
- - 100% open-source (#opensource)
GitHub: https://github.com/followtayeeb/llm-costs
npm: https://www.npmjs.com/package/llm-costs