### PR TITLE
Add AskePub to Text > Academia section

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [STORM](https://storm.genie.stanford.edu/) - An LLM-powered knowledge curation system that researches a topic and generates a full-length report with citations. [#opensource](https://github.com/stanford-oval/storm/)
 - [alphaXiv](https://www.alphaxiv.org) - Discuss, discover, and read arXiv papers.
 - [ASReview](https://asreview.nl/) - Open-source AI-powered tool for systematic reviews, helping researchers screen large volumes of academic literature efficiently. [#opensource](https://github.com/asreview/asreview)
+- [AskePub](https://github.com/GeiserX/AskePub) - Self-hosted Telegram bot that uses GPT-4o to generate AI study notes from ePub books. [#opensource](https://github.com/GeiserX/AskePub)
 
 ### Leaderboards
 - [Chatbot Arena](https://lmarena.ai/) - An open platform for crowdsourced AI benchmarking, hosted by researchers at UC Berkeley SkyLab and LMArena.


### PR DESCRIPTION
## Summary

- Adds [AskePub](https://github.com/GeiserX/AskePub) to the **Text > Academia** section.
- AskePub is a self-hosted Telegram bot that uses GPT-4o to generate AI study notes from ePub books. It is open source (MIT license), written in Python, and supports Docker deployment.
- Entry follows the existing format: `[ProjectName](Link) - Description.` and is added at the bottom of the Academia subsection, per CONTRIBUTING.md guidelines.
