### PR TITLE
Add Steel Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [ai-i18n](https://github.com/i18n-actions/ai-i18n) - A GitHub Action that uses LLMs (Claude, GPT, Ollama) to automatically translate i18n localization files. #opensource
 - [Groq](https://groq.com/) - A cloud inference API for running open-source LLMs, powered by custom LPU hardware.
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
+- [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
This adds Steel Browser to the Developer tools section.

Steel Browser is open-source browser sandbox and automation infrastructure for AI agents and apps. It fits here because it gives developer workflows a reliable browser layer for session-backed automation, screenshots, PDFs, proxies, and anti-bot-sensitive flows.

Links:
- Repo: https://github.com/steel-dev/steel-browser
- CLI: https://github.com/steel-dev/cli
- Docs: https://docs.steel.dev/
- Blog: https://steel.dev/blog/introducing-steel-cli-v0-2-0-browser-automation-built-for-agents

Example use case: use an AI coding workflow to automate a JS-heavy dashboard, extract content, and save screenshot or PDF artifacts.