### PR TITLE
Add onWatch to Discoveries list

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -121,6 +121,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Pixee](https://pixee.ai) - Pixeebot finds security and code quality issues in your code and creates merge-ready pull requests with recommended fixes.
 - [SQLAI.ai](https://www.sqlai.ai/) - Generate, fix, explain and optimize SQL. Get data insights and integrate your app with RAG-powered AI generators.
 - [NeuroLink](https://github.com/juspay/neurolink) - TypeScript-first AI SDK with multi-provider support, MCP integration, and multi-agent orchestration. #opensource
+- [onWatch](https://github.com/onllm-dev/onwatch) - CLI tool that tracks AI API quota usage across 6 providers (Anthropic, OpenAI, GitHub Copilot, and more) with a web dashboard. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [onWatch](https://github.com/onllm-dev/onwatch) to the **Coding > Developer tools** section of the Discoveries list.

**onWatch** is an open-source Go CLI that tracks AI API quota usage across 6 providers (Anthropic/Claude, OpenAI/Codex, GitHub Copilot, Synthetic, Z.ai, Antigravity). It runs as a background daemon with <50MB RAM, uses SQLite for local storage, has zero telemetry, and includes a Material Design 3 web dashboard. GPL-3.0 licensed.

- GitHub: https://github.com/onllm-dev/onwatch (~342 stars)
- Actively maintained, well-documented
- Entry added at the bottom of the Developer tools category per contribution guidelines