### PR TITLE
Add KeepRule - AI Investment Discipline Platform

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -258,6 +258,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GPU Per Hour](https://gpuperhour.com) - Real-time GPU cloud price comparison across multiple providers.
 - [DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) - A personal genome analysis toolkit powered by Claude Code that analyzes raw DNA data across 17 categories and generates terminal-style visualizations. #opensource
 - [Enconvo](https://enconvo.com) - A macOS AI launcher with a system-wide bar, voice input, multi-LLM support, and a plugin ecosystem.
+- [KeepRule](https://keeprule.com) - Investment-discipline tool with curated principles from 26 investors and AI prompts for scenario analysis.
 
 ## Learning resources
 


### PR DESCRIPTION
## Summary

- Adds [KeepRule](https://keeprule.com) to the **Other** section of DISCOVERIES.md
- KeepRule is an AI-powered investment discipline tracking platform featuring principles from 26 legendary investors (Buffett, Munger, Dalio, etc.), scenario analysis, and psychological tests
- It fits naturally alongside other finance/productivity AI tools like FinChat and Morpher AI in this list

## Why it fits this list

KeepRule uses generative AI to help investors analyze scenarios against proven investment principles and provides AI-driven psychological assessments for investment behavior. It's a unique application of AI in the finance/investment domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)