### PR TITLE
Add Fazm - AI desktop agent for macOS

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -173,6 +173,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Autohand Code CLI](https://github.com/autohandai/code-cli) - A terminal-based autonomous coding agent with multi-LLM support and a modular skills system. #opensource
 - [Frostbyte](https://frostbyte-api.vercel.app) - MCP server giving AI agents real-time tools: crypto prices, IP geolocation, DNS lookups, screenshots, and code execution.
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
+- [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 
 ### Custom assistants
 


### PR DESCRIPTION
## Summary

Adding [Fazm](https://fazm.ai) to the Agents > Autonomous agents section.

Fazm is the fastest open-source AI computer agent for macOS. It takes voice commands and controls your entire desktop - clicking, typing, navigating, writing code, managing documents. Uses direct DOM control at native speed instead of slow screenshot loops.

- **Website:** https://fazm.ai
- **GitHub:** https://github.com/m13v/fazm
- **Category:** Agents / Autonomous agents
- **Open source:** Yes