### PR TITLE
Add GEOScore AI to Other section

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -261,6 +261,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) - A personal genome analysis toolkit powered by Claude Code that analyzes raw DNA data across 17 categories and generates terminal-style visualizations. #opensource
 - [Enconvo](https://enconvo.com) - A macOS AI launcher with a system-wide bar, voice input, multi-LLM support, and a plugin ecosystem.
 - [KeepRule](https://keeprule.com) - Investment-discipline tool with curated principles from 26 investors and AI prompts for scenario analysis.
+- [GEOScore AI](https://geoscoreai.com/) - Free AI search visibility scanner that checks 11 GEO signals for ChatGPT, Perplexity, and Gemini visibility.
 
 ## Learning resources
 


### PR DESCRIPTION
## What is GEOScore AI?

GEOScore AI is a free tool that measures website visibility in AI search engines (ChatGPT, Perplexity, Gemini). It scans 11 GEO signals and provides actionable recommendations.

- Website: https://geoscoreai.com
- Free tier available
- Categories: AI, SEO, Analytics