### PR TITLE
Add Network-AI to Autonomous agents section

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -174,6 +174,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Frostbyte](https://frostbyte-api.vercel.app) - MCP server giving AI agents real-time tools: crypto prices, IP geolocation, DNS lookups, screenshots, and code execution.
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
+- [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds [Network-AI](https://github.com/Jovancoding/Network-AI) to the Autonomous agents section.

**What it is:** A TypeScript/Node.js multi-agent orchestrator with shared state (blackboard pattern), permission gating, token budgets, and compliance auditing. Ships 15 framework adapters (LangChain, AutoGen, CrewAI, OpenAI Assistants, LlamaIndex, Semantic Kernel, etc.) and 22 MCP tools.

- npm: [network-ai](https://www.npmjs.com/package/network-ai) (1,600+ weekly downloads)
- MIT licensed, 1,449 tests across 18 suites
- Listed on [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) and [Glama](https://glama.ai/mcp/servers/Jovancoding/network-ai) (A/A/A scores)