### PR TITLE
Add AI Developer Toolkit to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource
+- [AI Developer Toolkit](https://github.com/Money-Monkey-26/ai-dev-toolkit) - A collection of 32+ production-tested AI prompts for code review, debugging, testing, and architecture, compatible with Claude Code, ChatGPT, Cursor, and Copilot.
 
 ### Playgrounds
 - [OpenAI Playground](https://platform.openai.com/playground) - Explore resources, tutorials, API docs, and dynamic examples.


### PR DESCRIPTION
## Description

Add [AI Developer Toolkit](https://github.com/Money-Monkey-26/ai-dev-toolkit) to the **Developer tools** section under **Coding**.

AI Developer Toolkit is a collection of 32+ production-tested AI prompts for code review, debugging, testing, and architecture, compatible with Claude Code, ChatGPT, Cursor, and Copilot.

## Checklist

- [x] Entry added at the bottom of the relevant category
- [x] Entry follows the format: `[Title](URL) - Description.`
- [x] Description is concise and ends with a period
- [x] No trailing whitespace