### PR TITLE
Add Azex Speech to Speech-to-text

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -188,6 +188,8 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 ### Speech-to-text
 
+- [Azex Speech](https://github.com/azex-ai/speech) - Mac native voice input tool with local AI speech recognition (FireRedASR). 1800+ domain terms for Crypto & AI professionals. Open source.
+
 ### Music
 - [Boomy](https://boomy.com/) - Create original songs in seconds.
 - [Soundraw](https://soundraw.io/) - Create your beats with the power of AI.


### PR DESCRIPTION
## Description

Adds [Azex Speech](https://github.com/azex-ai/speech) to the **Speech-to-text** section of the Discoveries list.

**Entry added:**

```
- [Azex Speech](https://github.com/azex-ai/speech) - Mac native voice input tool with local AI speech recognition (FireRedASR). 1800+ domain terms for Crypto & AI professionals. Open source.
```

## About Azex Speech

- Mac menu bar app with global hotkey and floating editable panel
- Local AI speech recognition using FireRedASR (no cloud dependency for core features)
- 1800+ bundled domain vocabulary terms for Crypto & AI professionals
- Implicit learning from user corrections (personal vocab system)
- Open source, built with Swift 6 + SwiftUI for macOS 14+

## Placement

Added to `DISCOVERIES.md` under **Audio > Speech-to-text**, following the contribution guidelines for projects that are early-stage / community showcases.