### PR TITLE
Add Rapid-MLX to Local LLM Deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Generative Artificial Intelligence is a technology that creates original content
 
 ### Local LLM Deployment
 - [Ollama](https://github.com/ollama/ollama) - Get up and running with large language models locally.
+- [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) - OpenAI-compatible local LLM inference server optimized for Apple Silicon, 2-4x faster than Ollama. Supports tool calling, reasoning, vision, and structured output. #opensource
 - [Open WebUI](https://github.com/open-webui/open-webui) - An extensible, feature-rich, and user-friendly self-hosted AI platform designed to operate entirely offline. #opensource
 - [Jan](https://jan.ai/) - Run LLMs like Mistral or Llama2 locally and offline on your computer, or connect to remote AI APIs. [#opensource](https://github.com/janhq/jan)
 - [Msty](https://msty.app/) - A straightforward and powerful interface for local and online AI models.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [RunThisLLM](https://runthisllm.com) - See which LLMs you can run on your hardware.
 - [Harbor](https://github.com/av/harbor) - A containerized toolkit for running local LLM backends, UIs, and supporting services with one command. #opensource
 - [off-grid-mobile](https://github.com/alichherawalla/off-grid-mobile-ai) - React Native app for running LLMs, vision models, and Stable Diffusion on-device on iOS and Android without internet access. #opensource
+- [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) - OpenAI-compatible local LLM inference server optimized for Apple Silicon, with tool calling, reasoning, vision, and structured output support. #opensource
 
 ## Agents
 


### PR DESCRIPTION
## Summary

Adds [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) to the **Local LLM Deployment** section, placed next to Ollama as a related tool.

**What is Rapid-MLX?**
- OpenAI-compatible local LLM inference server optimized for Apple Silicon (M1/M2/M3/M4)
- 2-4x faster than Ollama on Apple Silicon benchmarks
- Supports tool calling, reasoning models (thinking), vision (multimodal), and structured output
- Apache-2.0 licensed, open source

**Why it fits this list:**
- Directly comparable to Ollama (local LLM deployment) but specifically optimized for the Apple Silicon ecosystem via MLX
- Fills a gap in the list for Apple Silicon-native inference tooling
- Active project with growing adoption in the Apple Silicon community