### PR TITLE
Add Podcasts subsection to Learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,14 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Build a Large Language Model (From Scratch)](https://www.manning.com/books/build-a-large-language-model-from-scratch) - A guide to building your own working LLM, by Sebastian Raschka.
 - [Prompt Engineering for Vision Models](https://www.deeplearning.ai/short-courses/prompt-engineering-for-vision-models/) - A free DeepLearning.AI short course on how to prompt computer vision models with natural language, bounding boxes, segmentation masks, coordinate points, and other images.
 
+### Podcasts
+
+- [Chain of Thought](https://chainofthought.show/) - A weekly podcast with AI leaders covering inference infrastructure, developer tools, and AI strategy.
+- [How I AI](https://www.youtube.com/@howiaipodcast) - Claire Vo interviews builders about how they use AI in practice.
+- [Latent Space](https://www.latent.space/podcast) - Technical deep dives into AI engineering, LLMs, and the developer tooling stack.
+- [Practical AI](https://practicalai.fm/) - AI made practical and accessible, from the Changelog network.
+- [TWIML AI](https://twimlai.com/) - Interviews with researchers and practitioners across the ML field.
+
 ## More lists
 
 - [Tools and Resources for AI Art](https://pharmapsychotic.com/tools.html) - A large list of Google Colab notebooks for generative AI, by [@pharmapsychotic](https://twitter.com/pharmapsychotic).


### PR DESCRIPTION
Adds a Podcasts subsection under Learning resources with five actively maintained AI podcasts covering engineering, tooling, research, and practical applications.