### PR TITLE
Add ClawSearch - Security-first AI agent skill search engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Davika](https://github.com/stitionai/devika) - An agentic AI software engineer. #opensource
 - [n8n](https://n8n.io/) - A workflow automation platform that combines AI capabilities with business process automation.
 - [Sauna](https://www.sauna.ai) - An AI assistant built for compounding context. It learns your taste, detects hidden patterns, augments your brain context and works proactively.
+- [ClawSearch](https://clawsearch.com) - A security-first AI agent skill search engine for safe discovery of MCP servers and tool integrations.
 - [Claude Code](https://code.claude.com) - Anthropic's agentic coding tool that lives in your terminal and helps you turn ideas into code.
 - [Gemini CLI](https://geminicli.com) - An open-source AI agent that brings the power of Gemini directly into your terminal. [#opensource](https://github.com/google-gemini/gemini-cli)
 - [Mastra](https://mastra.ai) - An all-in-one framework for building AI-powered applications and agents.


### PR DESCRIPTION
## Summary

- Adds [ClawSearch](https://clawsearch.com) to the **Autonomous agents** section under **Agents**
- ClawSearch is a security-first AI agent skill search engine for safe discovery of MCP servers and tool integrations
- Entry placed alphabetically between babyagi/AgentGPT entries and Claude Code

## Format

Follows the existing markdown list entry format: `- [Name](url) - Description.`