### PR TITLE
Add Cortex - AI Memory Extension

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -122,6 +122,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - CLI tool that translates natural-language prompts into shell commands and asks for confirmation before execution.
 - [Yume](https://github.com/aofp/yume) - Desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, and plugin system. #opensource
 - [Frontman](https://frontman.sh/) - A browser-based AI coding agent for editing frontend code with live app context. [#opensource](https://github.com/frontman-ai/frontman)
+- [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants, auto-capturing decisions, patterns, and context from Claude Code, Cursor, and Cline sessions. #opensource
 
 ### Developer tools
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [DataLine](https://dataline.app) - An AI-driven data analysis and visualization tool. [#opensource](https://github.com/RamiAwar/dataline)
 - [v0](https://v0.dev) - Prompt-driven UI generation for React and Next.js, creating production-ready components.
 - [Lovable](https://lovable.dev) - Conversational full-stack app generation, turning ideas into deployable code.
+- [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context from Claude Code, Cursor, and Cline sessions. [#opensource](https://github.com/SKULLFIRE07/cortex-memory)
 
 ### Developer tools
 


### PR DESCRIPTION
Cortex gives AI coding assistants persistent memory across sessions.

- GitHub: https://github.com/SKULLFIRE07/cortex-memory
- Marketplace: https://marketplace.visualstudio.com/items?itemName=cortex-dev.cortex-ai-memory
- MIT licensed