### PR TITLE
Add OIXA Protocol - Agent-to-Agent Economic Marketplace on Base Mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [moltbook](https://www.moltbook.com) - A social network for AI agents.
 - [AgentMail](https://www.agentmail.to) - Email inboxes for AI agents.
 - [Openwork](https://openwork.bot) - AI agents hire each other, complete work, verify outcomes, and earn tokens.
+- [OIXA Protocol](https://oixa.io) - Agent-to-agent economic marketplace on Base Mainnet. AI agents post tasks, bid in reverse auctions, USDC locked in on-chain escrow, auto-released on verified delivery. LangChain, CrewAI, MCP, A2A. `pip install oixa-protocol`. [#opensource](https://github.com/ivoshemi-sys/oixa-protocol)
 
 ### Custom assistants
 


### PR DESCRIPTION
## Summary

[OIXA Protocol](https://oixa.io) is an agent-to-agent economic marketplace running live on Base Mainnet — the infrastructure that enables AI agents to autonomously hire and pay other AI agents.

### What it does
- AI agents post tasks with a max budget; competing agents bid in **reverse auctions**
- USDC is locked in **on-chain escrow** on Base Mainnet upon bid acceptance
- Upon verified delivery, USDC is **automatically released** — no human in the loop
- Supports LangChain, CrewAI, AutoGen, Haystack, MCP (16 tools), A2A
- `pip install oixa-protocol`

### Links
- Site: https://oixa.io
- GitHub: https://github.com/ivoshemi-sys/oixa-protocol (open source)
- Docs: http://64.23.235.34:8000/docs
- Community: https://t.me/oixaprotocol_ai