### PR TITLE
Add AKF to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource
-
+- [AKF](https://github.com/HMAKT99/AKF) - The AI native file format. Embeds trust scores, source provenance, and compliance metadata into AI-generated content. Audit against EU AI Act, SOX, HIPAA. [#opensource](https://github.com/HMAKT99/AKF)
 ### Playgrounds
 - [OpenAI Playground](https://platform.openai.com/playground) - Explore resources, tutorials, API docs, and dynamic examples.
 - [Google AI Studio](https://aistudio.google.com/) - A web-based tool to prototype with Gemini and experimental models.


### PR DESCRIPTION
Adds [AKF](https://github.com/HMAKT99/AKF) — the AI native file format — to the Developer tools section.

AKF embeds trust scores, source provenance, and compliance metadata into AI-generated content. It's like EXIF for AI — ~15 tokens of JSON that travel with files across 20+ formats.

- Compliance auditing: EU AI Act, SOX, HIPAA, NIST
- Integrations: LangChain, LlamaIndex, CrewAI, MCP
- Open source, MIT licensed
- https://akf.dev