### PR TITLE
Add AI Model Benchmarks 2026 to Leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 Generative Artificial Intelligence is a technology that creates original content such as images, sounds, and texts by using machine learning algorithms that are trained on large amounts of data. Unlike other forms of AI, it is capable of creating unique and previously unseen outputs such as photorealistic images, digital art, music, and writing. These outputs often have their own unique style and can even be hard to distinguish from human-created works. Generative AI has a wide range of applications in fields such as of art, entertainment, marketing, academia, and computer science.
 
-
 ## Contents
 
 - [Recommended reading](#recommended-reading)
@@ -140,11 +139,13 @@ Generative Artificial Intelligence is a technology that creates original content
 - [ASReview](https://asreview.nl/) - Open-source AI-powered tool for systematic reviews, helping researchers screen large volumes of academic literature efficiently. [#opensource](https://github.com/asreview/asreview)
 
 ### Leaderboards
+
 - [Chatbot Arena](https://lmarena.ai/) - An open platform for crowdsourced AI benchmarking, hosted by researchers at UC Berkeley SkyLab and LMArena.
 - [Artificial Analysis](https://artificialanalysis.ai/) - Artificial Analysis provides objective benchmarks & information to help choose AI models and hosting providers.
 - [imgsys](https://imgsys.org/rankings) - A generative image model arena by fal.ai.
 - [OpenRouter LLM Rankings](https://openrouter.ai/rankings) - Language models ranked and analyzed by usage across apps.
 - [SEAL LLM Leaderboard](https://scale.com/leaderboard) - Expert-driven LLM benchmarks and updated AI model leaderboards.
+- [AI Model Benchmarks 2026](https://github.com/LARIkoz/ai-model-benchmarks) - 119 models with per-score freshness dates, structured JSON for agent routing, daily auto-updates, capability profiles. MIT.
 
 ### Other text generators
 
@@ -206,11 +207,13 @@ Generative Artificial Intelligence is a technology that creates original content
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource
 
 ### Playgrounds
+
 - [OpenAI Playground](https://platform.openai.com/playground) - Explore resources, tutorials, API docs, and dynamic examples.
 - [Google AI Studio](https://aistudio.google.com/) - A web-based tool to prototype with Gemini and experimental models.
 - [GitHub Models](https://github.com/marketplace/models) - Find and experiment with AI models to develop a generative AI application.
 
 ### Local LLM Deployment
+
 - [Ollama](https://github.com/ollama/ollama) - Get up and running with large language models locally.
 - [Open WebUI](https://github.com/open-webui/open-webui) - An extensible, feature-rich, and user-friendly self-hosted AI platform designed to operate entirely offline. #opensource
 - [Jan](https://jan.ai/) - Run LLMs like Mistral or Llama2 locally and offline on your computer, or connect to remote AI APIs. [#opensource](https://github.com/janhq/jan)
@@ -361,6 +364,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Bark](https://github.com/suno-ai/bark) - A transformer-based text-to-audio model. #opensource
 
 ### Speech-to-text
+
 - [Whisper](https://openai.com/index/whisper/) - Robust speech recognition via large-scale weak supervision. [#opensource](https://github.com/openai/whisper)
 - [Wispr Flow](https://wisprflow.ai/) - Flow makes writing quick with seamless voice dictation for any application on your computer.
 - [Vibe Transcribe](https://thewh1teagle.github.io/vibe/) - All-in-one solution for effortless audio and video transcription. [#opensource](https://github.com/thewh1teagle/vibe)


### PR DESCRIPTION
Adds [AI Model Benchmarks 2026](https://github.com/LARIkoz/ai-model-benchmarks) to the Leaderboards section.

119 models with per-score freshness dates, structured JSON for agent/pipeline routing, daily auto-updates via GitHub Actions, task routing matrix, and capability profiles. MIT licensed.

Complements existing entries (Chatbot Arena, Artificial Analysis, SEAL) with structured, machine-readable benchmark data.