### PR TITLE
Add CodeCosts to Coding Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [DataLine](https://dataline.app) - An AI-driven data analysis and visualization tool. [#opensource](https://github.com/RamiAwar/dataline)
 - [v0](https://v0.dev) - Prompt-driven UI generation for React and Next.js, creating production-ready components.
 - [Lovable](https://lovable.dev) - Conversational full-stack app generation, turning ideas into deployable code.
+- [CodeCosts](https://codecosts.pages.dev) - Compare pricing and features across AI coding tools including Copilot, Cursor, Claude Code, and Windsurf. Free API available.
 
 ### Developer tools
 


### PR DESCRIPTION
## Summary

- Adds [CodeCosts](https://codecosts.pages.dev) to the **Coding Assistants** section
- CodeCosts is a pricing comparison site for AI coding tools (Copilot, Cursor, Claude Code, Windsurf, etc.) with a free public API
- Entry follows the existing list format