### PR TITLE
Add ClipSpeedAI to Discoveries - Video

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -228,6 +228,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [ClipSpeedAI](https://www.clipspeed.ai/) - Finds the best moments in long-form videos and livestreams and turns them into captioned vertical clips.
 
 ### Avatars
 


### PR DESCRIPTION
Adds ClipSpeedAI to the Discoveries list under Video.

Rebased onto current main — the original branch had gone stale. Single line, no other changes.

Submitting to Discoveries rather than the Main List per CONTRIBUTING.md.