### PR TITLE
Add TokRepo to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource
+- [TokRepo](https://tokrepo.com) - Open registry for AI assets that lets developers and agents search and install skills, prompts, MCP configs, and workflows via CLI or MCP.
 
 ### Playgrounds
 - [OpenAI Playground](https://platform.openai.com/playground) - Explore resources, tutorials, API docs, and dynamic examples.


### PR DESCRIPTION
Adds TokRepo under Developer tools.

TokRepo is an open registry for AI assets that makes skills, prompts, MCP configs, and workflows searchable and installable from a CLI or MCP client.

It seemed like a reasonable fit alongside developer-facing tools such as Gitingest and Repomix because it helps developers and agents discover reusable AI assets instead of only generating or packaging code.
