### PR TITLE
Add VeroQ Shield - LLM output verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource
+- [VeroQ Shield](https://github.com/veroq-ai/shield) - Verify any LLM output in one function call. Extracts claims, fact-checks against live evidence, and returns trust scores with corrections.
 
 ### Playgrounds
 - [OpenAI Playground](https://platform.openai.com/playground) - Explore resources, tutorials, API docs, and dynamic examples.


### PR DESCRIPTION
## What is VeroQ?

[VeroQ Shield](https://github.com/veroq-ai/shield) verifies any LLM output in one function call:

```python
from veroq import shield
result = shield("NVIDIA reported $22B in Q4 revenue")
print(result.trust_score)   # 0.73
print(result.corrections)   # [{claim, correction}]
```

- Extracts claims from any LLM text
- Verifies each against live evidence (web search, financial data, public records)
- Returns trust score, corrections, and permanent verification receipts
- Python (`pip install veroq`) and TypeScript (`npm install @veroq/sdk`)
- 2,000+ weekly installs across npm and PyPI