### PR TITLE
Add Framecraft to Discoveries — Video

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -175,6 +175,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Viggle AI](https://viggle.ai/) - AI-powered video generation with character animation and motion control.
 - [TopView](https://www.topview.ai/) - Turn your links or media assets into viral videos in one click.
 - [OpenCreator](https://opencreator.ai) - An all-in-one AI workspace for creating product visuals (images and videos) with workflow automation and batch generation.
+- [Framecraft](https://github.com/vaddisrinivas/framecraft) - Open-source LLM plugin that generates polished 1920x1080 demo videos with voiceover and transitions from a single prompt. #opensource
 
 ### Avatars
 


### PR DESCRIPTION
## What is Framecraft?

[Framecraft](https://github.com/vaddisrinivas/framecraft) is an open-source LLM plugin that generates polished 1920x1080 demo videos with voiceover and transitions from a single prompt. It orchestrates Playwright, FFmpeg, and Edge TTS.

## Placement

Added to the **Discoveries** list under the **Video** section, as the project is new and may not yet meet the 1,000-follower threshold for the main list.

**License:** MIT

## Checklist

- [x] Follows `[ProjectName](Link) - Description.` format
- [x] Added to bottom of Video section
- [x] Description is concise and ends with a period
- [x] Includes #opensource tag