### PR TITLE
Add Agentify to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource
+- [Agentify](https://github.com/koriyoshi2041/agentify) - An open-source Agent Interface Compiler that transforms OpenAPI specs into 9 agent formats including MCP servers, AGENTS.md, and Skills. [#opensource](https://github.com/koriyoshi2041/agentify)
 
 ### Playgrounds
 - [OpenAI Playground](https://platform.openai.com/playground) - Explore resources, tutorials, API docs, and dynamic examples.


### PR DESCRIPTION
## What is Agentify?

[Agentify](https://github.com/koriyoshi2041/agentify) is an open-source **Agent Interface Compiler** that transforms any OpenAPI spec into 9 agent interface formats with a single command:

```
npx agentify-cli transform <openapi-spec>
```

### Supported output formats

- MCP Server
- AGENTS.md
- CLAUDE.md
- .cursorrules
- Skills (JSON)
- llms.txt
- GEMINI.md
- A2A Card
- CLI

### Why it belongs here

- **Open source** (MIT license) — [GitHub](https://github.com/koriyoshi2041/agentify)
- **Published on npm** — [agentify-cli](https://www.npmjs.com/package/agentify-cli) (v0.4.3)
- **Actively maintained** with 133+ tests passing
- Fills a unique niche: no other tool compiles a single OpenAPI spec into multiple agent interface formats
- Directly relevant to the Developer tools category as it helps developers make their APIs agent-ready