### PR TITLE
Add LongTrainer to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.
 - [LangChain](https://langchain.com/) - A framework for developing applications powered by language models.
+- [LongTrainer](https://github.com/ENDEVSOLS/Long-Trainer) - A production-ready RAG framework built on top of LangChain that handles multi-bot isolation, long-term memory, and streaming.
 - [gpt4all](https://github.com/nomic-ai/gpt4all) - A chatbot trained on a massive collection of clean assistant data including code, stories and dialogue.
 - [LLM App](https://github.com/pathwaycom/llm-app) - Open-source Python library to build real-time LLM-enabled data pipeline.
 - [LMQL](https://lmql.ai/) - LMQL is a query language for large language models.


### PR DESCRIPTION
Hi there! 👋

I would like to propose adding **[LongTrainer](https://github.com/ENDEVSOLS/Long-Trainer)** to this awesome list. 

### What is LongTrainer?
LongTrainer is a production-ready framework built on top of LangChain. It allows developers to turn their documents into intelligent, multi-tenant chatbots with just a few lines of code. 

### Why is it a good fit here?
It abstracts away the complexities of manually wiring together chains, memory, tools, and retrievers by offering batteries-included features for production:
- **Multi-bot architecture:** Built-in multi-tenant isolation for managing separate bots effortlessly.
- **Persistent Memory:** Ready-to-use MongoDB-backed, encrypted chat history.
- **Agentic Capabilities:** Supports both standard RAG pipelines and dynamic LangGraph agent tool-calling (web search, custom functions).
- **Extensive Document & Vision Support:** Natively parses PDFs, databases, URLs, and multi-modal images without friction.
- **Streaming:** First-class support for sync and async streaming out of the box.

I believe this will be an extremely valuable, time-saving resource for developers in this community looking to spin up robust GenAI/RAG applications in production quickly.

Thank you for your time and for maintaining this awesome list! Let me know if you need me to adjust the formatting to better fit the repository guidelines. 
