### PR TITLE
Add QueryGPT to Coding > Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Cursor](https://www.cursor.so/) - Cursor is the IDE of the future, built for pair-programming with Powerful AI.
 - [SymbolicAI](https://github.com/Xpitfire/symbolicai) - A neuro-symbolic framework for building applications with LLMs at the core.
 - [Vanna.ai](https://vanna.ai/) - An open-source Python RAG framework for SQL generation and related functionality. [#opensource](https://github.com/vanna-ai/vanna)
+- [QueryGPT](https://github.com/MoonMao42/QueryGPT) - Self-hosted text-to-SQL tool with natural language queries, Python analysis, and chart generation. [#opensource](https://github.com/MoonMao42/QueryGPT)
 - [Portkey](https://portkey.ai/) - A full-stack LLMOps platform for LLM monitoring, caching, and management.
 - [agenta](https://github.com/agenta-ai/agenta) - An open-source end-to-end LLMOps platform for prompt engineering, evaluation, and deployment. #opensource
 - [Together AI](https://www.together.ai/) - Train, fine-tune-and run inference on AI models blazing fast, at low cost, and at production scale.


### PR DESCRIPTION
Adding [QueryGPT](https://github.com/MoonMao42/QueryGPT) to the Developer Tools section, near Vanna.ai since they're both in the text-to-SQL space.

QueryGPT is a self-hosted text-to-SQL tool where you ask questions in natural language, get read-only SQL, and optionally get Python analysis with charts. It includes a semantic layer for defining business terms and a visual schema relationship graph for managing table JOINs. Open source, MIT licensed.