### PR TITLE
Add Typer - free local AI chat for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [LLM](https://llm.datasette.io/) - A CLI utility and Python library for interacting with Large Language Models, remote and local. [#opensource](https://github.com/simonw/llm)
 - [LM Studio](https://lmstudio.ai) - Download and run local LLMs on your computer.
 - [RunThisLLM](https://runthisllm.com) - See which LLMs you can run on your hardware.
+- [Typer](https://typer.space) - Free local AI chat for macOS. Runs entirely on-device — no account, no cloud, no ads. Works offline. Apple Silicon required.
 
 ## Agents
 


### PR DESCRIPTION
Typer is a free local AI chat app for macOS (Apple Silicon). It runs AI models entirely on-device — no account required, no cloud, no ads — and works fully offline.

It fits the **Local LLM Deployment** section alongside Jan, LM Studio, and Msty as a user-facing app for running AI locally. Added after RunThisLLM.

Website: https://typer.space