### PR TITLE
Add Onepilot to Coding Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Lovable](https://lovable.dev) - Conversational full-stack app generation, turning ideas into deployable code.
 - [aider](https://aider.chat/) - AI pair programming in your terminal, supporting multiple LLM providers. [#opensource](https://github.com/paul-gauthier/aider)
 - [Kilo Code](https://kilocode.ai) - Open-source AI coding assistant for VS Code, JetBrains, and the CLI. [#opensource](https://github.com/Kilo-Org/kilocode)
+- [Onepilot](https://onepilotapp.com) - An iOS app for SSHing into remote servers to run Claude Code, Codex, and other CLI coding tools from your phone.
 
 ### Developer tools
 


### PR DESCRIPTION
Adds [Onepilot](https://onepilotapp.com) to the Coding Assistants section.

Onepilot is an iOS app for SSHing into remote servers to run Claude Code, Codex, and other CLI coding tools from your phone. Useful for developers who want to monitor, manage, or kick off sessions on the go.

Entry added at the bottom of the Coding Assistants section, following the contribution guidelines.