### PR TITLE
Add AuditZap to Other section

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Scenario](https://www.scenario.com/) - AI-generated gaming assets.
 - [Teleprompter](https://github.com/danielgross/teleprompter) - An on-device AI for your meetings that listens to you and makes charismatic quote suggestions.
 - [FinChat](https://finchat.io/) - Using AI, FinChat generates answers to questions about public companies and investors.
+- [AuditZap](https://auditzap.io/) - AI-powered website audit tool that runs 24 checks and uses Claude AI to generate code-level fix instructions ranked by revenue impact.
 - [Morpher AI](https://morpher.com/ai) - Morpher AI delivers real-time insights and analysis for any market.
 - [Whimsical AI](https://whimsical.com/ai) - GPT-powered mind mapping, flowcharts, and visual tools for rapid idea development and process organization.
 - [Selfies with Sama](https://selfies-with-sama.vost.ai) - Grab a picture with a real-life billionaire!


### PR DESCRIPTION
Adding [AuditZap](https://auditzap.io/) to the Other section.

AI-powered website audit tool that uses Claude AI to generate code-level fix instructions for every failed check, ranked by revenue impact. Runs 24 automated checks across SEO, performance, and site health.

- Live at https://auditzap.io
- Free tier available

Disclosure: I am the creator of AuditZap.