### PR TITLE
Add Agent Brain to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Openwork](https://openwork.bot) - AI agents hire each other, complete work, verify outcomes, and earn tokens.
 - [Agent Skills](https://agentskills.io) - Open format and reference SDK for packaging reusable capabilities and expertise for AI agents. [#opensource](https://github.com/agentskills/agentskills)
 - [PraisonAI](https://github.com/MervinPraison/PraisonAI) - A framework for building multi-agent AI systems with workflows, tool integrations, and memory. #opensource
+- [Agent Brain](https://github.com/kaderosio/agent-brain) - A 7-layer cognitive memory system for AI agents using PostgreSQL, pgvector, and spaCy. No LLM required. [#opensource](https://github.com/kaderosio/agent-brain)
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds [Agent Brain](https://github.com/kaderosio/agent-brain) to the Autonomous agents section.

Agent Brain is a 7-layer cognitive memory system for AI agents. Built with Python, FastAPI, PostgreSQL, pgvector, and spaCy. Self-hostable, AGPLv3 licensed, no LLM required for memory operations.