### PR TITLE
Add Ailuminaty — LLM brand visibility audit tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 ## Other
 
 - [Diagram](https://diagram.com/) - Magical new ways to design products.
+- [Ailuminaty](https://ailuminaty.com/) - LLM brand visibility audit service. Checks how ChatGPT, Claude, Perplexity, and Gemini describe your brand, identifies errors, and generates corrections.
 - [PromptBase](https://promptbase.com/) - A marketplace for buying and selling quality prompts for DALL·E, GPT-3, Midjourney, Stable Diffusion.
 - [This Image Does Not Exist](https://thisimagedoesnotexist.com/) - Test your ability to tell if an image is human or computer generated.
 - [Have I Been Trained?](https://haveibeentrained.com/) - Check if your image has been used to train popular AI art models.


### PR DESCRIPTION
Added [Ailuminaty](https://ailuminaty.com/) to the **Other** section.

Ailuminaty is a brand visibility audit service that queries ChatGPT, Claude, Perplexity, and Gemini to show how they describe a given company, identifies hallucinations and errors, and generates structured data corrections.