### PR TITLE
Add SBproxy to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Meta's LLaMA model (and others) in pure C/C++. #opensource
 - [bitnet.cpp](https://github.com/microsoft/BitNet) - Official inference framework for 1-bit LLMs, by Microsoft. [#opensource](https://github.com/microsoft/BitNet)
 - [OpenRouter](https://openrouter.ai/) - A unified interface for LLMs. [#opensource](https://github.com/OpenRouterTeam)
+- [SBproxy](https://github.com/soapbucket/sbproxy) - Open source AI gateway and reverse proxy. Routes traffic across 103+ LLM providers with cost-based routing, rate limiting, guardrails, and semantic caching from a single YAML config.
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource


### PR DESCRIPTION
Add SBproxy to the Developer tools section.

SBproxy is an open source AI gateway that sits in front of LLM providers and gives teams a single API endpoint with multi-provider routing, automatic failover, cost-based routing, rate limiting, guardrails, and semantic caching. Supports 103+ providers including OpenAI, Anthropic, Google, AWS Bedrock, Azure, and local models. Single Go binary, Apache 2.0.

- https://sbproxy.dev
- https://github.com/soapbucket/sbproxy