### PR TITLE
Add SwarmVault to Developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -147,6 +147,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AI/ML API](https://aimlapi.com/) - Unified API for accessing multiple AI models across text, image, audio, and video.
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
+- [SwarmVault](https://github.com/swarmclawai/swarmvault) - Local-first knowledge compiler that turns files, URLs, PDFs, and code into a markdown wiki with a graph and search index. Ships a CLI, MCP server, and Obsidian plugin. [#opensource](https://github.com/swarmclawai/swarmvault)
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds a single-line entry for SwarmVault to the Developer tools section of DISCOVERIES.md (since the project sits below the 1,000 follower bar for the main list).

SwarmVault is a local-first knowledge compiler that turns files, URLs, PDFs, and code into a markdown wiki with a graph and search index. It ships a CLI, an MCP server, an Obsidian plugin, a desktop app, and a ClawHub skill. Provider-pluggable across Anthropic, OpenAI, Ollama, Gemini, and others, with a heuristic offline mode.

- Repo: https://github.com/swarmclawai/swarmvault
- License: MIT
- Active: daily commits, v0.7.30 shipped this week

Appended at the bottom of the Developer tools section to preserve existing order. Diff is a single insertion.
