### PR TITLE
Add Convo to Meeting assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Loopin AI](https://www.loopinhq.com/) - Loopin is a collaborative meeting workspace that not only enables you to record, transcribe & summaries meetings using AI, but also enables you to auto-organise meeting notes on top of your calendar.
 - [Read AI](https://www.read.ai/) - An AI copilot for wherever you work, making your meetings, emails, and messages more productive with summaries, content discovery, and recommendations.
 - [Fireflies.ai](https://fireflies.ai) - Transcribe, summarize, search, and analyze all your team conversations.
+- [Convo](https://www.itsconvo.com/) - Real-time AI meeting assistant that listens to your meetings and suggests what to say next, plus automated follow-ups.
 
 ### Academia
 


### PR DESCRIPTION
Adding [Convo](https://www.itsconvo.com/) to the Meeting assistants section.

Convo is a real-time AI meeting assistant that listens to your meetings and suggests what to say next, plus automated follow-ups.

- Entry added to the bottom of the Meeting assistants category
- Follows the contribution format: `[Name](URL) - Description.`