### PR TITLE
Add Mengram to Autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Openwork](https://openwork.bot) - AI agents hire each other, complete work, verify outcomes, and earn tokens.
 - [Agent Skills](https://agentskills.io) - Open format and reference SDK for packaging reusable capabilities and expertise for AI agents. [#opensource](https://github.com/agentskills/agentskills)
 - [PraisonAI](https://github.com/MervinPraison/PraisonAI) - A framework for building multi-agent AI systems with workflows, tool integrations, and memory. #opensource
+- [Mengram](https://mengram.io) - Open-source memory infrastructure for AI agents with semantic, episodic, and procedural memory layers and auto-reflection. [#opensource](https://github.com/alibaizhanov/mengram)
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds [Mengram](https://mengram.io) to the Autonomous agents section. Mengram is open-source memory infrastructure for AI agents with semantic, episodic, and procedural memory layers and auto-reflection. Source: https://github.com/alibaizhanov/mengram