### PR TITLE
Add rl-router to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [rl-router](https://github.com/ElromEvedElElyon/rl-router) - Contextual Thompson Sampling router for multi-provider LLM APIs. Adapts to rate limits and failures. Zero config, zero deps, MIT. [#opensource](https://github.com/ElromEvedElElyon/rl-router)
 
 ### Playgrounds
 


### PR DESCRIPTION
This PR adds rl-router to the Developer tools section under Coding.

What it is: An open-source Python library that routes LLM requests across multiple providers (OpenAI, Anthropic, Google, local) using Contextual Thompson Sampling, automatically adapting to rate limits and provider failures. Same category as existing entries OpenRouter and Portkey.

License and deps: MIT, Python 3.9+, zero external dependencies.

Repository: https://github.com/ElromEvedElElyon/rl-router

If the maintainer prefers, please feel free to route this entry to DISCOVERIES.md instead.