### PR TITLE
Add Burn 451 — AI reading tool with curated thought-leader vaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 
 ### Productivity
 
+- [Burn 451](https://www.burn451.cloud) - AI-powered reading tool with curated vaults (Andrej Karpathy, Simon Willison, Paul Graham, Naval Ravikant) and hub concept pages on agentic engineering and vibe coding. Each piece has an AI summary. [#opensource](https://github.com/Fisher521/killmybookmark)
 - [ChatPDF](https://www.chatpdf.com/) - Chat with any PDF.
 - [Mem](https://mem.ai/) - Mem is the world's first AI-powered workspace that's personalized to you. Amplify your creativity, automate the mundane, and stay organized automatically.
 - [Taskade](https://www.taskade.com/) - Outline tasks, notes, generated structured lists and mind maps with Taskade AI.


### PR DESCRIPTION
Hi — adding [Burn 451](https://www.burn451.cloud) to the Productivity section.

**What it is:** An AI-powered reading tool. Curated editorial vaults of essays, podcast picks, and talks from high-signal AI / startup thinkers:
- [Karpathy](https://www.burn451.cloud/vault/karpathy) (37 pieces)
- [Simon Willison](https://www.burn451.cloud/vault/simon-willison) (19)
- [Paul Graham](https://www.burn451.cloud/vault/paul-graham) (30)
- [Naval Ravikant](https://www.burn451.cloud/vault/naval-ravikant) (22)

Plus hub concept pages:
- [Agentic Engineering](https://www.burn451.cloud/concepts/agentic-engineering)
- [Vibe Coding](https://www.burn451.cloud/concepts/vibe-coding)

Each piece has an AI summary so you can triage in 5 seconds. Open source: https://github.com/Fisher521/killmybookmark