### PR TITLE
Add Not Human Search to Search engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Phind](https://phind.com/) - AI-based search engine.
 - [You.com](https://you.com/) - A search engine built on AI that provides users with a customized search experience while keeping their data 100% private.
 - [Komo](https://komo.ai/) - An AI-powered search engine.
+- [Not Human Search](https://nothumansearch.ai) - Search engine built for AI agents, indexing 720+ agent-ready tools ranked by API availability, llms.txt, OpenAPI specs, and MCP servers.
 
 ### Local search engines
 


### PR DESCRIPTION
Adds Not Human Search (https://nothumansearch.ai) to Text > Search engines.

NHS is a search engine built for AI agents, indexing 720+ agent-ready tools ranked by API availability, llms.txt, OpenAPI specs, and MCP servers.