### PR TITLE
Add DiamantAI open-source repos + RAG Made Simple book to Learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,10 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Build an AI Agent (From Scratch)](https://www.manning.com/books/build-an-ai-agent-from-scratch) - A book about building AI agents with tools, memory, planning, and multi-agent systems.
 - [Build a DeepSeek Model (From Scratch)](https://www.manning.com/books/build-a-deepseek-model-from-scratch) - A book about implementing DeepSeek-style LLM architecture, training, and distillation methods.
 - [AI Governance](https://www.manning.com/books/ai-governance) - A book about governance, risk, compliance, security, privacy, and oversight for generative AI systems.
+- [RAG Techniques](https://github.com/NirDiamant/RAG_Techniques) - A hands-on collection of advanced Retrieval-Augmented Generation tutorials covering chunking, query transformations, hybrid search, reranking, self-query, graph RAG, and evaluation, as runnable Jupyter notebooks. [#opensource](https://github.com/NirDiamant/RAG_Techniques)
+- [Agents Towards Production](https://github.com/NirDiamant/agents-towards-production) - An open-source playbook for shipping production-grade GenAI agents, covering memory, tool routing, guardrails, GPU deployment, observability, multi-agent coordination, and evaluation. [#opensource](https://github.com/NirDiamant/agents-towards-production)
+- [GenAI Agents](https://github.com/NirDiamant/GenAI_Agents) - A comprehensive collection of GenAI agent implementations and multi-agent architectures, from simple conversational bots to advanced agentic systems, as runnable tutorials. [#opensource](https://github.com/NirDiamant/GenAI_Agents)
+- [RAG Made Simple](https://www.amazon.com/dp/B0D76734SZ) - A visual guide to Retrieval-Augmented Generation covering 22 techniques with intuition, side-by-side comparisons, and illustrations, by Nir Diamant.
 
 ## More lists
 


### PR DESCRIPTION
Adds four resources to the **Learning resources** section (bottom of category, per contribution guidelines).

### What's added

- **[RAG Techniques](https://github.com/NirDiamant/RAG_Techniques)** (27K+ ⭐) — open-source Jupyter notebook tutorials for advanced RAG patterns: chunking, query transformations (HyDE, multi-query), hybrid search, reranking, self-query, parent-child retrieval, graph RAG, multi-hop retrieval, evaluation.
- **[Agents Towards Production](https://github.com/NirDiamant/agents-towards-production)** (17K+ ⭐) — open-source playbook for shipping production-grade GenAI agents: memory, tool routing, guardrails, GPU deployment, observability, multi-agent coordination.
- **[GenAI Agents](https://github.com/NirDiamant/GenAI_Agents)** (19K+ ⭐) — collection of GenAI agent implementations and multi-agent architectures as runnable tutorials.
- **[RAG Made Simple](https://www.amazon.com/dp/B0D76734SZ)** — #1 Amazon Best Seller in Generative AI (April 2026); the book companion to the RAG Techniques repo.

### Why these fit

All four meet the list's inclusion criteria:

- Stars: each repo is well above the 1,000-star threshold (7K–27K stars).
- Actively maintained, well-documented.
- Thematically they fit the Learning resources section alongside existing entries like the [OpenAI Cookbook](https://github.com/openai/openai-cookbook), [Anthropic courses](https://github.com/anthropics/courses), [Prompt Engineering Guide](https://github.com/dair-ai/Prompt-Engineering-Guide), and the Manning "Build a ___ From Scratch" book series.

### Format compliance

- Format: `[ProjectName](Link) - Description.`  ✅
- Added at the bottom of the category.  ✅
- Concise, period at end.  ✅

Author: [Nir Diamant](https://diamant-ai.com) (DiamantAI).