### PR TITLE
Add AI Dev Jobs to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [AI Dev Jobs](https://aidevboard.com/) - AI developer job board with REST API and MCP server. Search 7,400+ AI/ML roles from 417 companies programmatically.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com/) to the Developer tools section.

AI Dev Jobs provides a REST API and MCP server that let developers and AI agents programmatically search 7,400+ AI/ML job listings from 417 companies. It fits the Developer tools section as infrastructure that generative AI agents can use via tool-use (MCP protocol) to access job market data.