### PR TITLE
Add VoxArena to Discoveries > Leaderboards

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -99,6 +99,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 ### Leaderboards
 
 - [Price Per Token](https://pricepertoken.com/) - A tool for comparing LLM API pricing, token usage, and model benchmarks.
+- [VoxArena](https://voxarena.ai/) - Multi-LLM debate arena where Claude, GPT-4, Gemini, Grok, Mistral, and others argue opposing positions on any topic in real time, with structured verdicts, audience voting, and 7-language audio.
 
 ### Other text generators
 


### PR DESCRIPTION
Adds VoxArena (https://voxarena.ai) to the Discoveries > Leaderboards section.

Similar in spirit to Chatbot Arena (already in the Main List): a platform where multiple frontier LLMs (Anthropic Claude, OpenAI GPT-4, Google Gemini, xAI Grok, Mistral, Meta Llama, and Perplexity Sonar) compete head-to-head. The twist is adversarial debate on any proposition rather than blind preference ranking, with a third judge model producing structured verdicts.

Free to use, no login required to watch. Actively maintained.

Format follows CONTRIBUTING.md: `[Name](URL) - Description.`