### PR TITLE
Add AgentsMesh to Autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Agent Skills](https://agentskills.io) - Open format and reference SDK for packaging reusable capabilities and expertise for AI agents. [#opensource](https://github.com/agentskills/agentskills)
 - [PraisonAI](https://github.com/MervinPraison/PraisonAI) - A framework for building multi-agent AI systems with workflows, tool integrations, and memory. #opensource
 - [Hermes Agent](https://hermes-agent.nousresearch.com) - A self-improving personal agent with memory, messaging integrations, and sandboxed tool execution. [#opensource](https://github.com/NousResearch/hermes-agent)
+- [AgentsMesh](https://agentsmesh.ai) - Self-hostable AI Agent Workforce Platform with remote AI workstations (AgentPods), multi-agent collaboration via channels, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode. [#opensource](https://github.com/AgentsMesh/AgentsMesh)
 
 ### Custom assistants
 


### PR DESCRIPTION
Adding [AgentsMesh](https://agentsmesh.ai) to **Agents → Autonomous agents**.

## Why
AgentsMesh is a self-hostable AI Agent Workforce Platform with:
- **AgentPods** — remote AI workstations (PTY sandbox + git worktree isolation per task)
- **Multi-agent collaboration** via channels and pod bindings
- **Built-in Kanban** with ticket-pod binding and MR/PR integration
- **Per-pod MCP server** — Claude Code / Cursor can drive AgentsMesh
- **Self-hosted runners** — your code never leaves your infrastructure
- **Multi-Git** (GitHub / GitLab / Gitee), multi-tenant, SSO/RBAC/audit, BYOK
- Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode

1.5k+ stars, v0.28.0 (2026-04-15), BSL-1.1 (→ GPL-2.0 on 2030-02-28). Appended after Hermes Agent following existing bullet format.