### PR TITLE
Add PQS (Prompt Quality Score) to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [PQS (Prompt Quality Score)](https://pqs.onchainintel.net/) - Pre-inference prompt scoring on 8 quality dimensions. GitHub Action, Python SDK (LangChain / CrewAI / AutoGen integrations), MCP server, REST API. [#opensource](https://github.com/OnChainAIIntel)
 
 ### Playgrounds
 


### PR DESCRIPTION
## What this adds

Adds [**PQS (Prompt Quality Score)**](https://pqs.onchainintel.net/) to the **Developer tools** section.

## Why it fits here

PQS is a pre-inference prompt scoring system — same developer-tooling category as Langfuse, Cleanlab, Helicone, Opik, Portkey, and agenta already listed in this section. It grades any prompt on 8 dimensions (clarity, specificity, context, constraints, output format, role definition, examples, CoT structure) using PEEM, RAGAS, MT-Bench, G-Eval, ROUGE.

Complementary to existing entries:
- **Langfuse / Opik / Helicone** trace and observe LLM *outputs*
- **Cleanlab** scores LLM *output* hallucinations
- **PQS** scores prompt *inputs* pre-flight — before any LLM call runs

## Ecosystem

- **GitHub Action**: [PQS Check](https://github.com/marketplace/actions/pqs-check) (GitHub Marketplace)
- **Python SDK**: [prompt-quality-score](https://pypi.org/project/prompt-quality-score/) on PyPI (LangChain + CrewAI + AutoGen integrations)
- **MCP server**: [pqs-mcp-server](https://www.npmjs.com/package/pqs-mcp-server) on npm (Smithery 88/100, Glama Official)
- **REST API**: free tier, no signup

MIT licensed. Happy to rework description or move to a different section if a better fit exists.
