### PR TITLE
Add QuickSilver Pro (DeepSeek V3, R1, Qwen API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Meta's LLaMA model (and others) in pure C/C++. #opensource
 - [bitnet.cpp](https://github.com/microsoft/BitNet) - Official inference framework for 1-bit LLMs, by Microsoft. [#opensource](https://github.com/microsoft/BitNet)
 - [OpenRouter](https://openrouter.ai/) - A unified interface for LLMs. [#opensource](https://github.com/OpenRouterTeam)
+- [QuickSilver Pro](https://quicksilverpro.io/) - OpenAI-compatible inference API for DeepSeek V3, DeepSeek R1, and Qwen3.5-35B-A3B at 20% below competing resellers. Drop-in replacement — change only the base URL.
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource


### PR DESCRIPTION
Adds [QuickSilver Pro](https://quicksilverpro.io) to the **Coding → Developer tools** section.

QuickSilver Pro is an OpenAI-compatible inference API reselling three open-source LLMs — DeepSeek V3, DeepSeek R1, and Qwen3.5-35B-A3B — at 20% below OpenRouter, Together AI, and Fireworks AI on the same models. Placed immediately after the OpenRouter entry since they are the closest categorical neighbors.

Diff:
\`\`\`
- [OpenRouter](https://openrouter.ai/) - A unified interface for LLMs. [#opensource](https://github.com/OpenRouterTeam)
+ [QuickSilver Pro](https://quicksilverpro.io/) - OpenAI-compatible inference API for DeepSeek V3, DeepSeek R1, and Qwen3.5-35B-A3B at 20% below competing resellers. Drop-in replacement — change only the base URL.
\`\`\`

**Disclosure**: I help operate QuickSilver Pro. Happy to revise description length or category if it's a better fit elsewhere.