### PR TITLE
Add MeterCall - 2,866 SaaS alternatives, pay per call

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [MeterCall](https://metercall.ai) - 2,866+ SaaS alternatives. Pay per call, no subscription. Open catalog at [patl4588/awesome-saas-replacements](https://github.com/patl4588/awesome-saas-replacements).
 
 ### Playgrounds
 


### PR DESCRIPTION
MeterCall is a pay-per-call alternative to 2,866+ SaaS products. Every module is open for use or forking; builders keep 70%.

Catalog: https://github.com/patl4588/awesome-saas-replacements
Site: https://metercall.ai

Happy to adjust placement or wording if this isn't the right section - feel free to close if not a fit.