### PR TITLE
Add Haldir (governance layer for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [Haldir](https://haldir.xyz/) - Governance layer for AI agents. Per-session scopes with spend caps, AES-encrypted secrets the model never sees, hash-chained tamper-evident audit, and policy enforcement proxy. Native SDKs for LangChain, CrewAI, and Vercel AI SDK. [#opensource](https://github.com/ExposureGuard/haldir)
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [Haldir](https://haldir.xyz/) to the **Developer tools** section.

**What it is:** A governance layer purpose-built for AI agents. Per-session scopes with spend caps, AES-encrypted secrets the model never sees, hash-chained tamper-evident audit trail, and a policy enforcement proxy for tool calls.

**Why it fits this list:** It sits alongside the other LLM/agent dev tools already here (Langfuse, Phoenix, Helicone, Portkey) — but focused on **enforcement and governance** rather than observability. Ships native SDKs for LangChain, CrewAI, and Vercel AI SDK.

**Placement:** Developer tools section, end of list (consistent with recent additions). One-line format matches siblings.