### PR TITLE
Add AI Workflow Benchmark, CloudWright, and kb-arena to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -148,6 +148,9 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AI/ML API](https://aimlapi.com/) - Unified API for accessing multiple AI models across text, image, audio, and video.
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
+- [AI Workflow Benchmark](https://github.com/xmpuspus/ai-workflow-benchmark) - Benchmark harness measuring AI coding tool and workflow performance on 100 real engineering tasks across 8 categories, with 12 capability dimensions and vanilla-vs-custom workflow comparison. #opensource
+- [CloudWright](https://github.com/xmpuspus/cloudwright) - AI-powered cloud architecture that turns natural-language descriptions into Terraform, cost estimates, and multi-framework compliance reports (HIPAA, PCI-DSS, SOC 2, FedRAMP, GDPR). #opensource
+- [kb-arena](https://github.com/xmpuspus/kb-arena) - RAG evaluation arena that benchmarks 7 retrieval strategies (naive vector, contextual, QnA pairs, knowledge graph, RAPTOR, PageIndex, hybrid) on your own docs with ELO-based blind A/B ranking and RAGAS metrics. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds three open-source AI tools to the **Coding > Developer tools** section of DISCOVERIES.md (current star counts are below the 1k main-list bar, so submitting to Discoveries per the contribution guidelines).

## Tools

- **[CloudWright](https://github.com/xmpuspus/cloudwright)** — AI-powered cloud architecture generator. Describes infrastructure in natural language; produces Terraform/CloudFormation, cost estimates, compliance reports (HIPAA, PCI-DSS, SOC 2, FedRAMP, GDPR, Well-Architected), and Mermaid diagrams. Multi-cloud (AWS, GCP, Azure, Databricks). Ships CLI + web UI + MCP server for agent integration.
- **[kb-arena](https://github.com/xmpuspus/kb-arena)** — RAG evaluation arena. Benchmarks 7 retrieval strategies (naive vector, contextual vector, QnA pairs, knowledge graph, RAPTOR, PageIndex, hybrid) on user-provided docs. ELO-based blind A/B Strategy Arena, RAGAS metrics, auto-generated questions across 5 difficulty tiers, supports Anthropic/OpenAI/Ollama.
- **[AI Workflow Benchmark](https://github.com/xmpuspus/ai-workflow-benchmark)** — Benchmark harness measuring AI coding tool + workflow performance (not just model capability). 100 real engineering tasks across 8 categories, 12 capability dimensions, sigmoid-normalized scoring, statistical significance testing for workflow lift.

## Checklist per CONTRIBUTING.md

- [x] Format: `[ProjectName](Link) - Description.`
- [x] Added to the bottom of Coding > Developer tools in DISCOVERIES.md
- [x] Descriptions end with periods
- [x] Trailing whitespace removed
- [x] All three projects are actively maintained (last commits April 2026)
- [x] All three are well-documented with READMEs and production-grade test suites

Happy to split into separate PRs if preferred.