### PR TITLE
Add AceTagGen — Suno AI prompt builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [AIVA](https://www.aiva.ai/) - AI-based music generation assistant. Choose from 250+ styles.
 - [Suno AI](https://www.suno.ai/) - Anyone can make great music. No instrument needed, just imagination. From your mind to music.
 - [Udio](https://www.udio.com/) - Discover, create, and share music with the world.
+- [AceTagGen](https://acetaggen.com/) - Free structured prompt builder for Suno AI — 3,000+ tested tags, 12-step questionnaire, built-in quality score, respects Suno's 200-character Style limit. Also offers a free [public scoring API](https://acetaggen.com/api/suno-score).
 
 ## Other
 


### PR DESCRIPTION
Adding [AceTagGen](https://acetaggen.com) to the Music section.

**What it is:** Free structured prompt builder for Suno AI music generation. Fills the tooling gap between "type something and hope" and the actual model — via a 12-step questionnaire that assembles Suno-ready prompts from 3,000+ curated tags tested on Suno v4/v4.5.

**Why it fits here:**
- Section already lists Suno AI and Udio as two primary AI music platforms
- AceTagGen is the most mature freely-available *prompt-building* layer for Suno, with no signup required for the free tier
- Includes a [free public API](https://acetaggen.com/api/suno-score) (`GET /api/suno-score?prompt=...`) for any dev building on Suno

**Entry placed** directly after Udio, since it pairs naturally with the Suno listing.

Happy to adjust wording or placement. Thanks for maintaining this list — it's been my reference for months.