### PR TITLE
Add AIWatch to Other

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -250,6 +250,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Docket AI](https://docketai.com) - AI sales agent for reliably answering complex product questions.
 - [Chinese-Elite](https://github.com/anonym-g/Chinese-Elite) - An experimental project that uses LLMs to build a knowledge graph of Chinese political and business elites from public data. [#opensource](https://github.com/anonym-g/Chinese-Elite)
 - [GPU Per Hour](https://gpuperhour.com) - Real-time GPU cloud price comparison across multiple providers.
+- [AIWatch](https://ai-watch.dev) - Real-time status dashboard for 30 AI services (Claude, OpenAI, Gemini, and more) with AI-powered incident analysis and early detection vs official status pages. [#opensource](https://github.com/bentleypark/aiwatch)
 
 ## Learning resources
 


### PR DESCRIPTION
Adds AIWatch to the `Other` section of `DISCOVERIES.md`.

**AIWatch** — https://ai-watch.dev

Real-time status dashboard for 30 AI services (Claude, OpenAI, Gemini, Mistral, Cohere, Groq, and more) with:

- **AI-powered incident analysis** — hybrid Gemma 4 26B (Cloudflare Workers AI) + Claude Sonnet (fallback), summarizes cause and estimated recovery
- **Early detection** — direct API probing catches outages minutes ahead of official status pages
- **Open source**, free to access, no account required
- Stack: Cloudflare Workers + KV + Workers AI + React 19

GitHub: https://github.com/bentleypark/aiwatch

### Checklist

- [x] Entry follows format: `[ProjectName](Link) - Description.`
- [x] Added to bottom of category (`Other` section)
- [x] Description concise + ends with period
- [x] No trailing whitespace
- [x] Project is actively maintained (current month: 2026-04)
- [x] Documented (README + CLAUDE.md + per-issue workflow)
- [x] Placed in Discoveries list (below 1k-follower threshold for main list)