### PR TITLE
Add Claude API Pricing Calculator to Leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenRouter LLM Rankings](https://openrouter.ai/rankings) - Language models ranked and analyzed by usage across apps.
 - [SEAL LLM Leaderboard](https://scale.com/leaderboard) - Expert-driven LLM benchmarks and updated AI model leaderboards.
 - [LLM Stats](https://llm-stats.com/) - Compare AI models across benchmarks, pricing, speed, and context window.
+- [Claude API Pricing Calculator](https://claudeapipricing.com/) - Interactive calculator for estimating Claude API costs across Opus, Sonnet, and Haiku, including prompt caching and Batch API savings.
 
 ### Other text generators
 


### PR DESCRIPTION
Hi,

Adding a free interactive calculator for Claude API costs to the Leaderboards section, which already includes pricing-comparison resources like LLM Stats and Artificial Analysis.

- **Link:** https://claudeapipricing.com/
- **What it does:** Estimates Claude API costs across Opus, Sonnet, and Haiku, with support for prompt caching and Batch API savings.
- **Why it fits:** Developers building on Claude frequently need a quick way to model token costs before committing to a workload pattern. Complements LLM Stats (broad model comparison) with a focused Claude-specific cost calculator.

No affiliation with Anthropic. Vendor-neutral tool from an independent publisher.

Thanks for maintaining this list.