### PR TITLE
Add semantix-ai under Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [semantix-ai](https://github.com/labrat-akhona/semantix-ai) - Local, deterministic semantic validation for LLM outputs via a quantized NLI model. DSPy reward/metric, pytest assertions, hash-chained audit trail. [#opensource](https://github.com/labrat-akhona/semantix-ai)
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds semantix-ai under Developer tools.

semantix-ai is an open-source (MIT) Python library for validating LLM outputs against plain-English semantic intents using a local quantized NLI model (~25 MB ONNX, ~15 ms per call, deterministic, no API key).

- DSPy reward/metric functions (`BestOfN`, `Refine`, `Evaluate`, MIPROv2).
- pytest integration via [`pytest-semantix`](https://github.com/labrat-akhona/pytest-semantix).
- Hash-chained JSON-LD audit receipts for every validation — tamper-evident.
- Integrations: LangChain, Pydantic AI, Guardrails, Instructor, MCP.

- Repo: https://github.com/labrat-akhona/semantix-ai
- PyPI: https://pypi.org/project/semantix-ai/
- Docs: https://labrat-akhona.github.io/semantix-ai/
- License: MIT
