### PR TITLE
Add tteg to DISCOVERIES.md (Coding > Developer tools)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -148,6 +148,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AI/ML API](https://aimlapi.com/) - Unified API for accessing multiple AI models across text, image, audio, and video.
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
+- [tteg](https://tteg.kushalsm.com) - Stock photos for AI coding agents — real Unsplash images via CLI, HTTP API, or MCP, no API key required. Drop-in replacement for placeholder image URLs in AI-generated landing pages. [#opensource](https://github.com/kiluazen/tteg)
 
 ### Playgrounds
 


### PR DESCRIPTION
### What this adds

One entry in `DISCOVERIES.md` under **Coding → Developer tools**:

```markdown
- [tteg](https://tteg.kushalsm.com) - Stock photos for AI coding agents — real Unsplash images via CLI, HTTP API, or MCP, no API key required. Drop-in replacement for placeholder image URLs in AI-generated landing pages. [#opensource](https://github.com/kiluazen/tteg)
```

### Why it fits Discoveries (per CONTRIBUTING.md)

tteg is a small open-source project ([MIT](https://github.com/kiluazen/tteg/blob/main/LICENSE)) published to PyPI in early April 2026. It targets a specific, concrete pain in the AI-coding-agent workflow: every AI-generated landing page tends to ship with `placehold.co`, `via.placeholder.com`, or the deprecated `source.unsplash.com/random` URLs (the latter has been 503ing since mid-2024 and is present in 16k+ live GitHub files as of April 2026 — short [research note](https://github.com/kiluazen/tteg/blob/main/RESEARCH.md)). tteg gives agents and humans a zero-config way to get real Unsplash photos: `uv tool install tteg && tteg save "startup office" ./public/hero`, or a direct CORS-enabled HTTPS fetch from the public API.

The project is too small for the main list (well under the 1000-follower bar), but it's a live, working, useful tool in the Generative AI dev-tool corner, which is exactly what Discoveries is for.

### Formatting

- Format matches existing entries: `[Name](link) - Description.` ending with a period.
- Added to the **bottom** of the existing `Developer tools` sub-section.
- `[#opensource](...)` badge used per project's own convention (repo is public, MIT).
- No trailing whitespace.

### Links

- Landing: https://tteg.kushalsm.com
- Source: https://github.com/kiluazen/tteg
- Scanner (any URL → broken/placeholder image report): https://tteg.kushalsm.com/scan
- Research note on the broken-Unsplash pattern: https://github.com/kiluazen/tteg/blob/main/RESEARCH.md

Happy to adjust wording, move to a different sub-section, or drop if it's not a fit.