### PR TITLE
Add Scoreflow under Coding / Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [Scoreflow](https://scoreflow.dev/) - Craftsmanship Score for AI coding. Ingests OpenTelemetry from Claude Code, Copilot, and Cursor; scores developers on anti-Goodhart bands; delivers via MCP + email + dashboard. Team-aggregate first, EU-hosted.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds Scoreflow to the Coding → Developer tools section. Scoreflow is an observability layer for AI coding tools: it ingests OpenTelemetry from Claude Code + Copilot + Cursor and produces a Craftsmanship Score per developer (banded, anti-Goodhart).

- Repo: https://github.com/8infinitelabs/scoreflow
- Site: https://scoreflow.dev