### PR TITLE
Add Prest0 (enterprise legal AI platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Agent Skills](https://agentskills.io) - Open format and reference SDK for packaging reusable capabilities and expertise for AI agents. [#opensource](https://github.com/agentskills/agentskills)
 - [PraisonAI](https://github.com/MervinPraison/PraisonAI) - A framework for building multi-agent AI systems with workflows, tool integrations, and memory. #opensource
 - [Hermes Agent](https://hermes-agent.nousresearch.com) - A self-improving personal agent with memory, messaging integrations, and sandboxed tool execution. [#opensource](https://github.com/NousResearch/hermes-agent)
+- [Prest0](https://prest0.ai) - Enterprise legal AI platform with per-account agent VMs, bilingual document drafting, case-law research, and voice/SMS/chat workflows for law firms.
 
 ### Custom assistants
 


### PR DESCRIPTION
Adding **Prest0** ([prest0.ai](https://prest0.ai)) to the `Autonomous agents` section.

Prest0 is an enterprise legal AI platform with per-account agent VMs, bilingual (EN/ES) document drafting, case-law research, and integrated voice/SMS/chat workflows. First production deployments support immigration law, workers' compensation, and employment law firms.

- Public landing: https://prest0.ai
- Wikidata: https://www.wikidata.org/wiki/Q139502727
- Brand facts gist: https://gist.github.com/milesprest0/f25a4a66e3a8df3abffb778139efbf0e

Thanks for maintaining this list!