### PR TITLE
Add BenchGecko to Leaderboards section

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenRouter LLM Rankings](https://openrouter.ai/rankings) - Language models ranked and analyzed by usage across apps.
 - [SEAL LLM Leaderboard](https://scale.com/leaderboard) - Expert-driven LLM benchmarks and updated AI model leaderboards.
 - [LLM Stats](https://llm-stats.com/) - Compare AI models across benchmarks, pricing, speed, and context window.
+- [BenchGecko](https://benchgecko.ai) - AI model benchmarks, cross-provider pricing, and economy tracking. Covers thousands of models across hundreds of providers with daily updates.
 
 ### Other text generators
 


### PR DESCRIPTION
Adds BenchGecko to the Leaderboards section.

BenchGecko tracks thousands of AI models with benchmark scores, cross-provider pricing comparison, AI economy indicators, and agent leaderboards. Free API included.

https://benchgecko.ai