### PR TITLE
Add Murmure to Discoveries developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -148,6 +148,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AI/ML API](https://aimlapi.com/) - Unified API for accessing multiple AI models across text, image, audio, and video.
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
+- [Murmure — AI DevTools Community Sentiment Tracker](https://github.com/murmurecc/ai-devtools-sentiment) - Weekly sentiment analysis of AI developer tools (Cursor, Windsurf, Linear, Devin, etc.) based on Reddit, HN, GitHub Issues, and Discord.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds Murmure under `DISCOVERIES.md` > `Coding` > `Developer tools`.

Entry:
- Name: Murmure — AI DevTools Community Sentiment Tracker
- URL: https://github.com/murmurecc/ai-devtools-sentiment
- Description: Weekly sentiment analysis of AI developer tools (Cursor, Windsurf, Linear, Devin, etc.) based on Reddit, HN, GitHub Issues, and Discord.

I used the Discoveries list rather than the main README because your contribution guidelines reserve Discoveries for promising projects that may not yet meet main-list inclusion thresholds.