### PR TITLE
Add REG-Vault (retro-gaming metadata + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,3 +476,5 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [FlowGPT](https://flowgpt.com/) - Amplify your workflow with the best prompts.
 - [ChatGPT Prompts for Data Science](https://github.com/travistangvh/ChatGPT-Data-Science-Prompts) - A repository of useful data science prompts for ChatGPT.
 - [Awesome ChatGPT](https://github.com/sindresorhus/awesome-chatgpt) - Another awesome list for ChatGPT.
+
+- [REG-Vault](https://regvault.org) - Open retro-gaming metadata dataset (91k games, 99 systems). CC BY-SA 4.0. MCP + REST APIs for LLM grounding.


### PR DESCRIPTION
Adds **REG-Vault** — an open retro-gaming metadata catalog (91,000+ games, 99 systems) with REST API + MCP server at `api.regvault.org/mcp`.

- Home: https://regvault.org
- API docs: https://regvault.org/docs/api
- MCP endpoint: https://api.regvault.org/mcp (JSON-RPC 2.0, spec 2025-03-26)

Tools exposed: `list_systems`, `search_games`, `get_game`, `get_letter_counts`, `get_stats`.
