### PR TITLE
Add osModa to Autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Agent Skills](https://agentskills.io) - Open format and reference SDK for packaging reusable capabilities and expertise for AI agents. [#opensource](https://github.com/agentskills/agentskills)
 - [PraisonAI](https://github.com/MervinPraison/PraisonAI) - A framework for building multi-agent AI systems with workflows, tool integrations, and memory. #opensource
 - [Hermes Agent](https://hermes-agent.nousresearch.com) - A self-improving personal agent with memory, messaging integrations, and sandboxed tool execution. [#opensource](https://github.com/NousResearch/hermes-agent)
+- [osModa](https://github.com/bolivian-peru/os-moda) - NixOS distribution where the AI agent has root through 91 typed MCP tools — modular runtime swaps Claude Code and OpenClaw drivers per-agent without SSH or rebuild. Hash-chained audit ledger, atomic NixOS rollback, P2P encrypted mesh between servers. [#opensource](https://github.com/bolivian-peru/os-moda)
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds [osModa](https://github.com/bolivian-peru/os-moda) at the bottom of **Agents → Autonomous agents** (per CONTRIBUTING.md: "Add new entries to the bottom of their respective category").

osModa is a NixOS distribution where the AI agent has root through 91 typed MCP tools. Modular runtime — swap between `claude-code` and `openclaw` drivers per-agent at runtime via SIGHUP, no SSH or rebuild. Live deployment + ERC-8004 / A2A agent card at [spawn.os.moda](https://spawn.os.moda).

It complements the other autonomous-agent entries already in this section (OpenClaw, Hermes Agent, PraisonAI, Mastra) by providing the **operating-system layer** those agents need to live on — root-level system access mediated by typed tool calls and hash-chained audit, NixOS atomic rollback, P2P encrypted mesh between agent instances.

**Format check** (per CONTRIBUTING):
- Format: `[Name](URL) - Description.` ✓
- Inserted at the bottom of the relevant category ✓
- Description is concise, ends with a period, sentence case ✓
- License: Apache-2.0 ✓
- Actively maintained (last commit today) ✓
- 80★ — note this is below the 1,000-follower main-list threshold; happy for it to land in the [Discoveries list](https://github.com/steven2358/awesome-generative-ai/blob/main/DISCOVERIES.md) if that's the right home.

Thanks for maintaining the list.