### PR TITLE
Add RAG Chunking Planner to DISCOVERIES Developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -123,7 +123,6 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 ### Developer tools
 
-- **[RAG Chunking Planner](https://uatgpt.com/tools/rag-chunking-planner/)** - "Client-side RAG index sizer that estimates chunk counts, indexing and query costs, vector storage, and recommends an ANN algorithm based on corpus scale."
 - [Makelog](https://makelog.com/gpt3) - Automatically generate changelog posts using GPT-3 and Jira, Linear, GitHub, Shortcut, and Asana issues, tasks, and pull requests.
 - [Wilco Sierra](https://trywilco.com/sierra) - A platform that generates engineering challenges for software engineers using AI.
 - [Vectara](https://vectara.com/) - A Generative AI product platform for developers.
@@ -149,6 +148,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AI/ML API](https://aimlapi.com/) - Unified API for accessing multiple AI models across text, image, audio, and video.
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
+- **[RAG Chunking Planner](https://uatgpt.com/tools/rag-chunking-planner/)** - "Client-side RAG index sizer that estimates chunk counts, indexing and query costs, vector storage, and recommends an ANN algorithm based on corpus scale."
 
 ### Playgrounds
 

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -123,6 +123,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 ### Developer tools
 
+- **[RAG Chunking Planner](https://uatgpt.com/tools/rag-chunking-planner/)** - "Client-side RAG index sizer that estimates chunk counts, indexing and query costs, vector storage, and recommends an ANN algorithm based on corpus scale."
 - [Makelog](https://makelog.com/gpt3) - Automatically generate changelog posts using GPT-3 and Jira, Linear, GitHub, Shortcut, and Asana issues, tasks, and pull requests.
 - [Wilco Sierra](https://trywilco.com/sierra) - A platform that generates engineering challenges for software engineers using AI.
 - [Vectara](https://vectara.com/) - A Generative AI product platform for developers.


### PR DESCRIPTION
Adds RAG Chunking Planner to DISCOVERIES.md under Coding > Developer tools.

Why it fits the Developer tools section:
- Solves a pre-deploy capacity question developers hit when building RAG apps (chunks, cost, storage, context tokens, ANN pick).
- Runs client-side in the browser — no sign-up, no server call.
- Free and unmetered.
- Sits next to peers already listed (Ragie, Lunary, Fiddler.ai) but covers a different phase (pre-deploy planning rather than managed hosting or observability).

Criterion compliance:
- Submitting to DISCOVERIES.md, not README.md, because the project does not yet meet the 1,000+ followers criterion for the main list.

Happy to adjust wording or section placement if preferred.