### PR TITLE
Add AIToolTier to Leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenRouter LLM Rankings](https://openrouter.ai/rankings) - Language models ranked and analyzed by usage across apps.
 - [SEAL LLM Leaderboard](https://scale.com/leaderboard) - Expert-driven LLM benchmarks and updated AI model leaderboards.
 - [LLM Stats](https://llm-stats.com/) - Compare AI models across benchmarks, pricing, speed, and context window.
+- [AIToolTier](https://aitooltier.com/leaderboard) - Tier-list rankings (S-F) for 128+ AI tools across 23 categories, with per-benchmark leaderboards and editorial reviews.
 
 ### Other text generators
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenRouter LLM Rankings](https://openrouter.ai/rankings) - Language models ranked and analyzed by usage across apps.
 - [SEAL LLM Leaderboard](https://scale.com/leaderboard) - Expert-driven LLM benchmarks and updated AI model leaderboards.
 - [LLM Stats](https://llm-stats.com/) - Compare AI models across benchmarks, pricing, speed, and context window.
-- [AIToolTier](https://aitooltier.com/leaderboard) - Tier-list rankings (S-F) for 128+ AI tools across 23 categories, with per-benchmark leaderboards and editorial reviews.
+- [AIToolTier](https://aitooltier.com/leaderboard) - Tier-list rankings (S-F) for 140+ AI tools across 23 categories, with per-benchmark leaderboards and editorial reviews.
 
 ### Other text generators
 


### PR DESCRIPTION
## What

Adds [AIToolTier](https://aitooltier.com/leaderboard) to the Leaderboards subsection under Text.

## Why it fits Leaderboards

AIToolTier publishes ranked tier lists for 128+ AI tools across 23 categories, plus per-benchmark leaderboards for MMLU, GPQA Diamond, AIME, SWE-bench Verified, HumanEval, LiveCodeBench, ARC-AGI, Humanity's Last Exam, MATH, and MMLU-Pro. Structurally it's the same category of resource as the existing entries:

- Chatbot Arena / Artificial Analysis / SEAL / LLM Stats all publish ranked comparisons of LLMs
- imgsys ranks generative image models
- AIToolTier ranks tools across the full Generative AI ecosystem (LLMs + coding agents + image/video/music generators + agent frameworks) using a transparent S-F tier rubric

## Format check

- Follows the `[ProjectName](Link) - Description.` format
- Added to the bottom of the Leaderboards list
- Description ends with a period
- Under 1 line

## Quality notes

- No paid placements or advertiser-funded tier boosts
- Actively maintained (daily editorial sweeps)
- Methodology documented at /methodology and /how-we-review
- Structured data (schema.org `Review` + `AggregateRating` + `ItemList`) on all leaderboard and tool pages

If this doesn't meet inclusion criteria for the main list, happy to re-target to Discoveries.