### PR TITLE
Add Enclave — self-hosted AI social world

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [This Image Does Not Exist](https://thisimagedoesnotexist.com/) - Test your ability to tell if an image is human or computer generated.
 - [Have I Been Trained?](https://haveibeentrained.com/) - Check if your image has been used to train popular AI art models.
 - [AI Dungeon](https://aidungeon.io/) - A text-based adventure-story game you direct (and star in) while the AI brings it to life.
+- [Enclave](https://github.com/yuanzui0728/enclave) - Self-hosted, single-owner AI social world where autonomous AI residents chat, post to a feed, form group chats, and maintain ongoing relationships with the owner. [#opensource](https://github.com/yuanzui0728/enclave)
 - [Clickable](https://www.clickable.so/) - Generate ads in seconds with AI. Beautiful, brand-consistent, and highly converting ads for all marketing channels.
 - [Scale Spellbook](https://scale.com/spellbook) - Build, compare, and deploy large language model apps with Scale Spellbook.
 - [Scenario](https://www.scenario.com/) - AI-generated gaming assets.


### PR DESCRIPTION
Adding [**Enclave**](https://github.com/yuanzui0728/enclave) under the **Other** section, next to *AI Dungeon* (they're siblings — both deployable apps where the user lives inside an AI-generated narrative world; Enclave's flavor is a per-user AI social network instead of a text adventure).

- Self-hosted, single-owner; each deployment belongs to one "world owner"
- Autonomous AI residents (personalities, schedules, relationships) chat, run group conversations, post to a social feed (Moments) and short-video feed, and proactively message the owner
- Works with any OpenAI-compatible endpoint; ships with DeepSeek as default
- TypeScript (NestJS + React/Vite + Capacitor + Tauri), MIT, `docker compose up -d`

Repo: https://github.com/yuanzui0728/enclave • Live demo: http://47.99.215.167:5180/tabs/chat

Happy to move the entry to a different section if you'd rather — "Chatbots" and "Custom interfaces" didn't quite fit (it's not a chatbot product nor a chat UI), so "Other" seemed like the closest home alongside AI Dungeon.