### PR TITLE
Add Promptise Foundry to Discoveries - Agents

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -164,6 +164,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Maxim AI](https://www.getmaxim.ai) - An enterprise-grade generative AI evaluation and observability platform.
 - [Hercules](https://github.com/test-zeus-ai/testzeus-hercules) - An open-source AI agent for automated UI, API, security, and accessibility testing. [#opensource](https://github.com/test-zeus-ai/testzeus-hercules)
 - [Quorum](https://github.com/Detrol/quorum-cli) - A CLI for running structured debates across multiple LLMs. #opensource
+- [Promptise Foundry](https://github.com/promptise-com/foundry) - Production Python framework for agentic AI with controllable reasoning, a real MCP server SDK, autonomous runtime, memory, governance, security, and observability. [#opensource](https://github.com/promptise-com/foundry)
 
 ### Custom assistants
 


### PR DESCRIPTION
Adding [Promptise Foundry](https://github.com/promptise-com/foundry) to the Discoveries list under `Agents → Autonomous agents`.

Promptise Foundry is a production-grade, Apache 2.0, Python 3.10+ framework for building autonomous agents and MCP servers, actively maintained. It covers memory, MCP tool integration, an autonomous runtime with triggers and journals, governance (budget/health/mission/secrets), guardrails, a semantic cache, and observability — aimed at teams shipping real agentic systems rather than demos.

Currently at 812 stars, so submitting to the Discoveries list per the CONTRIBUTING.md criteria (<1,000 followers). Entry format follows the existing `[Name](url) - Description.` convention with `[#opensource]` tag and is appended to the bottom of the `Autonomous agents` category as requested in CONTRIBUTING.md.