### PR TITLE
Add FuturMix — Enterprise AI Agent Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [FuturMix](https://futurmix.ai/) - A unified AI gateway providing OpenAI-compatible access to 22+ models with 99.99% SLA.
 
 ### Playgrounds
 


### PR DESCRIPTION
## Add FuturMix

Adding [FuturMix](https://futurmix.ai) to the Developer tools section under Coding.

FuturMix is an enterprise AI agent platform that provides OpenAI-compatible access to 22+ models from OpenAI, Anthropic, and Google with 99.99% SLA.

- **Website**: https://futurmix.ai
- **Models**: 22+ (Claude, GPT, Gemini families)
- **Compatibility**: OpenAI SDK compatible