### PR TITLE
Add peyeeye to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Langfuse](https://langfuse.com/) - An open-source LLM engineering platform for tracing, evaluation, prompt management, and metrics. [#opensource](https://github.com/langfuse/langfuse)
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
+- [peyeeye](https://peyeeye.ai) - A PII redaction and rehydration API for LLM prompts with 60+ built-in entity types and custom entities. Stateful sessions or stateless AEAD-sealed blobs; Python + TypeScript SDKs with Vercel AI SDK, LangChain, and LiteLLM integrations.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
 
 ### Playgrounds


### PR DESCRIPTION
Adds [peyeeye](https://peyeeye.ai) to the Developer tools section, alongside the existing rehydra entry.

peyeeye is a PII redaction and rehydration API for LLM prompts: it strips emails, payment data, secrets, and 60+ built-in entity types from prompts before they reach the model, then rehydrates originals into the response. Custom entities for domain-specific identifiers are first-class. Two deployment modes — stateful sessions or stateless AEAD-sealed rehydration keys for zero-retention setups.

Python + TypeScript SDKs with drop-in middleware for the Vercel AI SDK, LangChain, LangChain.js, and LiteLLM.

**Disclosure:** I'm the author/maintainer of peyeeye. Happy to adjust wording/placement.