### PR TITLE
Add VibeXForge to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -250,6 +250,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Docket AI](https://docketai.com) - AI sales agent for reliably answering complex product questions.
 - [Chinese-Elite](https://github.com/anonym-g/Chinese-Elite) - An experimental project that uses LLMs to build a knowledge graph of Chinese political and business elites from public data. [#opensource](https://github.com/anonym-g/Chinese-Elite)
 - [GPU Per Hour](https://gpuperhour.com) - Real-time GPU cloud price comparison across multiple providers.
+- [VibeXForge](https://www.vibexforge.com) - AI launch platform that scores submitted projects with Claude across 5 dimensions and evolves them through 6 RPG stages on real engagement metrics. [#opensource](https://github.com/alex-jb/vibex)
 
 ## Learning resources
 


### PR DESCRIPTION
Adding VibeXForge to `DISCOVERIES.md` → `## Other` section per CONTRIBUTING.md (project under the 1k-follower threshold for the main list).

**What it does**: Submit a URL or GitHub repo, Claude Haiku 4.5 returns a structured review across 5 dimensions (originality, clarity, UX potential, virality potential, investor curiosity), and the project becomes a 16-bit pixel-art "hero card" that evolves through 6 RPG stages — Seed, Active, Growing, Breakout, Legend, Myth — based on real engagement (plays, upvotes, shares).

**Why `Other`**: closest fit. It's an AI-as-judge product with a long-running evolution loop, distinct from agents / coding tools / image / video / audio.

**Source-available** on GitHub at [alex-jb/vibex](https://github.com/alex-jb/vibex). Live at [vibexforge.com](https://www.vibexforge.com). Bilingual EN/ZH (~925 i18n strings). Entry follows the `[Name](link) - Description.` format with `#opensource` tag at the end matching existing convention.

Happy to adjust description length or section per your preference.