### PR TITLE
Add TranscribeText to Speech-to-text section

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Vibe Transcribe](https://thewh1teagle.github.io/vibe/) - All-in-one solution for effortless audio and video transcription. [#opensource](https://github.com/thewh1teagle/vibe)
 - [whisper.cpp](https://github.com/ggerganov/whisper.cpp) - Port of OpenAI's Whisper model in C/C++. #opensource
 - [whisper-ctranslate2](https://github.com/Softcatala/whisper-ctranslate2) - A Whisper CLI client compatible with the original OpenAI client, using CTranslate2 for faster inference. [#opensource](https://github.com/Softcatala/whisper-ctranslate2)
+- [TranscribeText](https://transcribetext.com) - AI-powered transcription supporting 41+ languages with speaker diarization, subtitle translation, and direct YouTube URL input. Processes a 2-hour audio file in under 2 minutes. Strong on under-served languages like Chinese, Tamil, Vietnamese, Japanese, and Korean.
 
 ### Music
 


### PR DESCRIPTION
Adds TranscribeText to the Speech-to-text section.

TranscribeText is a commercial AI transcription service supporting 41+ languages including Chinese, Tamil, Vietnamese, Japanese, and Korean — languages where most existing tools in this section underperform. Features speaker diarization, SRT/VTT subtitle export, subtitle translation, and direct YouTube URL input.

Disclosure: I am the founder of TranscribeText.

URL: https://transcribetext.com