### PR TITLE
Add pdfmux to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
 
+- [pdfmux](https://pdfmux.com) - Open-source PDF extraction orchestrator. Routes each page to the best of 5 backends (PyMuPDF, OpenDataLoader, RapidOCR, Docling) with optional BYOK LLM fallback. Per-page confidence scoring catches and re-extracts failures. Ranks #2 on opendataloader-bench (200 PDFs). [#opensource](https://github.com/NameetP/pdfmux)
+
 ### Playgrounds
 
 - [OpenAI Playground](https://platform.openai.com/playground) - Explore resources, tutorials, API docs, and dynamic examples.


### PR DESCRIPTION
Adds [pdfmux](https://pdfmux.com) (MIT, [github.com/NameetP/pdfmux](https://github.com/NameetP/pdfmux)) to the **Developer tools** section.

**What it is:** Open-source PDF extraction orchestrator. Routes each page to the best of 5 backends (PyMuPDF, OpenDataLoader, RapidOCR, Docling) with optional BYOK LLM fallback (Claude/GPT-4o/Gemini/Ollama). Per-page confidence scoring catches blank pages, mojibake, broken column order, and re-extracts failures with a stronger backend.

**Why it fits:** Pairs naturally with LlamaIndex / LangChain / Haystack — those are listed already in this section. pdfmux is the layer that gets clean text into them. Specifically built for RAG ingestion.

**Proof points:**
- Ranks #2 on [opendataloader-bench](https://pdfmux.com/blog/benchmarking-pdf-extractors/) (200 real-world PDFs, 0.900 overall — within noise of #1 closed paid SaaS at 0.909)
- MIT licensed, pip install
- Built-in MCP server for Claude Desktop / Cursor
- Recently added to: [awesome-langchain](https://github.com/kyrolabs/awesome-langchain) (9.3k★, merged 2026-04-26), [RAGHub](https://github.com/Andrew-Jang/RAGHub), [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) (85k★)

Happy to adjust the description or move the entry to a different section if you'd prefer.