### PR TITLE
Add lean-ctx to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [lean-ctx](https://leanctx.com/) - Open-source context runtime for AI coding agents (MCP server and shell hook) that reduces token costs through session caching, AST-aware compression, and shell output patterns. [#opensource](https://github.com/yvgude/lean-ctx)
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [lean-ctx](https://leanctx.com/) ([source](https://github.com/yvgude/lean-ctx)) to the Coding » Developer tools list, matching existing entry format and placement at the end of that subsection per CONTRIBUTING.md.