### PR TITLE
Add GPUforLLM to Local LLM Deployment (Live Hugging Face VRAM Calculator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [LM Studio](https://lmstudio.ai) - Download and run local LLMs on your computer.
 - [RunThisLLM](https://runthisllm.com) - See which LLMs you can run on your hardware.
 - [Harbor](https://github.com/av/harbor) - A containerized toolkit for running local LLM backends, UIs, and supporting services with one command. #opensource
+- [GPUforLLM](https://gpuforllm.com/) - A precise VRAM calculator that reads live Hugging Face configs to determine local hardware requirements for MoE and dense LLMs.
 
 ## Agents
 


### PR DESCRIPTION
Hi Steven,

Thanks for maintaining this incredible list.

I’d love to submit a free tool I built called **GPUforLLM**. A browser-based calculator that tells users exactly how much VRAM they need to run local LLMs on their own hardware.

Unlike most VRAM calculators that rely on static tables, GPUforLLM instead:

- Reads config.json directly from any Hugging Face model URL
- Computes memory requirements dynamically in the browser
- Handles advanced cases like MoE models (e.g. DeepSeek V3/R1) by separating Active vs Total params
- Accurately calculates KV cache using real GQA ratios and context lengths

The site has been live for ~5 months and has already helped 1,000+ organic users, demonstrating real-world usefulness.
(If helpful, I can also share analytics to verify usage)

I’ve added it under Local LLM Deployment and followed the contribution guidelines.
(Included a screenshot below for quick preview.)

If you think it’s a better fit for the Discoveries List, I’d be happy to be included there as well.

Thanks again for your time!

<img width="1416" height="893" alt="image" src="https://github.com/user-attachments/assets/097fdad3-e37a-4f82-b8d7-c7c7756a7d05" />
<img width="1352" height="906" alt="image" src="https://github.com/user-attachments/assets/85b96f83-e807-47cb-8746-7f468d449391" />
