### PR TITLE
Add Off Grid to Local LLM Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [LM Studio](https://lmstudio.ai) - Download and run local LLMs on your computer.
 - [RunThisLLM](https://runthisllm.com) - See which LLMs you can run on your hardware.
 - [Harbor](https://github.com/av/harbor) - A containerized toolkit for running local LLM backends, UIs, and supporting services with one command. #opensource
+- [Off Grid](https://github.com/alichherawalla/off-grid-mobile-ai) - Open-source iOS/Android app that runs LLMs entirely on-device via llama.cpp. Voice (Whisper), vision, image gen, tool calling — all offline, MIT-licensed. [#opensource](https://github.com/alichherawalla/off-grid-mobile-ai)
 
 ## Agents
 


### PR DESCRIPTION
Adds [Off Grid](https://github.com/alichherawalla/off-grid-mobile-ai) to **Text > Local LLM Deployment**.

Off Grid is the mobile-native member that section currently lacks — neighbors are all desktop (Ollama, Open WebUI, Jan, LM Studio).

- Open-source iOS/Android consumer app, MIT-licensed (1,785 stars)
- Runs LLMs entirely on-device via llama.cpp + GGUF
- Supports Llama, Qwen, Gemma, Phi, DeepSeek, Mistral
- Voice (Whisper), vision, on-device image generation, tool calling
- 100% offline, no account, no telemetry
- 10K+ Android installs, 4.3★ App Store

Following the existing entry format with `[#opensource](url)` suffix.