### PR TITLE
Add Uni-CLI to Discoveries (Coding > Developer tools)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -144,6 +144,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AI/ML API](https://aimlapi.com/) - Unified API for accessing multiple AI models across text, image, audio, and video.
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
+- [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Self-repairing CLI catalog exposing 237+ websites, desktop apps, and external CLIs as deterministic commands for AI agents via 920 declarative YAML adapters, structured error envelopes, and an optional MCP server. #opensource
 
 ### Playgrounds
 

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -144,7 +144,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AI/ML API](https://aimlapi.com/) - Unified API for accessing multiple AI models across text, image, audio, and video.
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
-- [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Self-repairing CLI catalog exposing 237+ websites, desktop apps, and external CLIs as deterministic commands for AI agents via 920 declarative YAML adapters, structured error envelopes, and an optional MCP server. #opensource
+- [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Self-repairing CLI catalog exposing 238 sites and 1,458 commands across web, desktop apps, Electron apps, and bridge CLIs as deterministic commands for AI agents. Declarative YAML adapters with structured error envelopes; ships an optional MCP server. #opensource
 
 ### Playgrounds
 

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -144,7 +144,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AI/ML API](https://aimlapi.com/) - Unified API for accessing multiple AI models across text, image, audio, and video.
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
-- [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Self-repairing CLI catalog exposing 238 sites and 1,458 commands across web, desktop apps, Electron apps, and bridge CLIs as deterministic commands for AI agents. Declarative YAML adapters with structured error envelopes; ships an optional MCP server. #opensource
+- [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Self-repairing CLI catalog that exposes web, desktop apps, Electron apps, and bridge CLIs as deterministic commands for AI agents. Declarative YAML adapters with structured error envelopes; ships an optional MCP server. Live catalog size tracked in the repo's README. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
## What
Adds [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) to **DISCOVERIES.md → Coding → Developer tools**.

## Why Discoveries (not Main)
The CONTRIBUTING guide reserves the main list for projects with 1,000+ followers or maintainer interest. Uni-CLI is at ~5★ today (the repo just moved from `ZenAlexa` to `olo-dot-io`); Discoveries is the right home per the inclusion criteria.

## What Uni-CLI does
Self-repairing CLI catalog exposing **237+ websites, desktop apps, and external CLIs** as deterministic commands for AI agents. 920 declarative YAML adapters + 216 TS adapters surface 3,319 commands. Ships an optional MCP server (stdio + Streamable HTTP).

The differentiator is **self-repair**: every error is a structured envelope (`code`, `adapter_path`, `step`, `suggestion`, `retryable`, `alternatives`) so when a target site rotates a selector or auth, the calling agent edits the YAML at `adapter_path` and retries — no maintainer in the loop.

## Format
- Followed `[name](link) - description.` convention.
- Description ends with period.
- Added `#opensource` tag (Apache-2.0).

## Project signals
- Apache-2.0, TypeScript strict, Node ≥ 20.
- npm: [`@zenalexa/unicli`](https://www.npmjs.com/package/@zenalexa/unicli).
- Latest release: v0.218.0 (2026-05-05).