### PR TITLE
Add Science AI Journal to Academia

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [alphaXiv](https://www.alphaxiv.org) - Discuss, discover, and read arXiv papers.
 - [ASReview](https://asreview.nl/) - Open-source AI-powered tool for systematic reviews, helping researchers screen large volumes of academic literature efficiently. [#opensource](https://github.com/asreview/asreview)
 - [Local Deep Research](https://github.com/LearningCircuit/local-deep-research) - A deep research tool for searching academic sources, the web, and private documents with local or cloud LLMs. [#opensource](https://github.com/LearningCircuit/local-deep-research)
+- [Science AI Journal](https://scienceaijournal.com) - AI toolkit for researchers: Pre-Check (free Tier 1-5 acceptance probability from title+abstract), AI Review (8 specialist LLM agents calibrated on 23K real peer reviews; structured editorial decision in 15 min), Research Gaps Finder (17K indexed gaps across 250M OpenAlex papers).
 
 ### Leaderboards
 


### PR DESCRIPTION
Adding Science AI Journal to the Academia section.

What it is:
- Three free/paid AI tools for researchers, all calibrated on 23,000 real peer reviews scraped from OpenReview, eLife, SciPost, PLOS ONE, BMJ Open, Nature Communications, F1000, and 9 other open-review platforms.
- **Pre-Check** (free, no signup): paste title + abstract, get a Tier 1-5 acceptance probability + 3 research-gap signals in 15 seconds.
- **AI Review** ($10 one-off / $15 mo): upload PDF, 8 specialist agents (methodology, statistics, originality, literature, reproducibility, language, figures, prior publication) return a structured editorial decision in 15 minutes.
- **Research Gaps Finder** (free): 17,000+ indexed gaps across 250M OpenAlex works.

Why Academia: it's a research-productivity toolkit for PhD students and researchers. Sits well next to Elicit, SciSpace, Consensus, and ASReview in the existing list -- same audience, different problem (peer review + gaps vs. literature search).

Format follows existing entries: `- [Name](URL) - Description.` (single hyphen separator).

Happy to amend wording or move to a different section if you'd prefer.