### PR TITLE
Add grounding-ai to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [grounding-ai](https://github.com/andyliszewski/grounding-ai) - A local-first RAG pipeline that ingests PDFs, EPUBs, and Word docs into a searchable index, queryable via an MCP server that returns chunks with exact page-and-section citations. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [grounding-ai](https://github.com/andyliszewski/grounding-ai) to the **Coding > Developer tools** section.

Local-first RAG pipeline that ingests PDFs, EPUBs, and Word docs into a searchable index, exposed via an MCP server that returns chunks with page-and-section citations. Fits alongside the existing RAG-framework entries in the section (Haystack, LangChain, LlamaIndex, Vanna.ai, Agentset) — grounding-ai differentiates by keeping ingestion, embeddings, and retrieval all local; the LLM layer is BYO (cloud or local).

Format: appended chronologically to the Developer tools list, matching existing entry style and `#opensource` annotation.