### PR TITLE
feat: add llm-prices to Leaderboards (Discoveries)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -98,6 +98,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 ### Leaderboards
 
 - [Price Per Token](https://pricepertoken.com/) - A tool for comparing LLM API pricing, token usage, and model benchmarks.
+- [llm-prices](https://github.com/benbencodes/llm-prices) - Zero-dependency CLI and Python library for comparing LLM API pricing across 43 models and 8 providers.
 
 ### Other text generators
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [LangChain](https://langchain.com/) - A framework for developing applications powered by language models.
 - [gpt4all](https://github.com/nomic-ai/gpt4all) - A chatbot trained on a massive collection of clean assistant data including code, stories and dialogue.
 - [LLM App](https://github.com/pathwaycom/llm-app) - Open-source Python library to build real-time LLM-enabled data pipeline.
+* [llm-prices](https://github.com/benbencodes/llm-prices): Zero-dependency CLI and Python library for looking up and comparing LLM API costs across 15 providers (OpenAI, Anthropic, Google, Mistral, Groq, Bedrock, and more). No API key required — pricing data is baked in.
 - [LMQL](https://lmql.ai/) - LMQL is a query language for large language models.
 - [LlamaIndex](https://www.llamaindex.ai/) - A data framework for building LLM applications over external data.
 - [Phoenix](https://phoenix.arize.com/) - Open-source tool for ML observability that runs in your notebook environment, by Arize. Monitor and fine tune LLM, CV and tabular models.


### PR DESCRIPTION
## Add llm-prices

**llm-prices** is a zero-dependency Python CLI and library for comparing LLM API pricing.

- GitHub: https://github.com/benbencodes/llm-prices
- 43 models across 8 providers (OpenAI, Anthropic, Google, Mistral, Groq, Cohere, DeepSeek, xAI)
- Complements Price Per Token in the Leaderboards section — offline/CLI alternative
- Zero runtime dependencies (Python stdlib only)

Submitting to Discoveries list per contribution guidelines.