### PR TITLE
Add Awesome AI Startups to More lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Awesome Music AI](https://github.com/steven2358/awesome-music-ai) - A curated list of AI tools for music composition, generation, and analysis.
 - [Awesome AI Market Maps](https://github.com/joylarkin/Awesome-AI-Market-Maps) - A curated list of AI market maps from 2026, 2025, and 2024, by [Joy Larkin](https://twitter.com/joy).
 - [Awesome RAG Production](https://github.com/Yigtwxx/Awesome-RAG-Production) - A curated list of tools and resources for building production RAG systems.
+- [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) - A curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders.
 
 ### Lists on ChatGPT
 


### PR DESCRIPTION
Adds [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) to the **More lists** section.

It's a curated directory of indie-built AI startups — bootstrapped, pre-seed, and angel-funded products only — organized into 18 categories (AI Agents, Coding, Audio/Voice, Image/Design, Marketing, etc.). Currently 440+ entries.

Fits alongside the existing Airtable-based startup lists and other curated AI list entries already in the section.

Followed the contributing guidelines:
- Format: `[Name](url) - Description.` ending with a period
- Added to the bottom of the existing section (before the `### Lists on ChatGPT` subsection)