### PR TITLE
docs: add RapidClaw managed hosting under Autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Agent Skills](https://agentskills.io) - Open format and reference SDK for packaging reusable capabilities and expertise for AI agents. [#opensource](https://github.com/agentskills/agentskills)
 - [PraisonAI](https://github.com/MervinPraison/PraisonAI) - A framework for building multi-agent AI systems with workflows, tool integrations, and memory. #opensource
 - [Hermes Agent](https://hermes-agent.nousresearch.com) - A self-improving personal agent with memory, messaging integrations, and sandboxed tool execution. [#opensource](https://github.com/NousResearch/hermes-agent)
+- [RapidClaw](https://rapidclaw.dev) - Managed cloud hosting for OpenClaw and Hermes agents; see the [OpenClaw hosting cost: self-host vs managed breakdown](https://rapidclaw.dev/blog/openclaw-hosting-cost-self-host-vs-managed).
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds RapidClaw, a managed cloud hosting option for the OpenClaw and Hermes Agent entries already in this list.