### PR TITLE
Add future-agi by Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [Future AGI](https://github.com/future-agi/future-agi) - An open-source end-to-end agent engineering and optimization platform that unifies tracing, evals, simulations, datasets, gateway, and guardrails for shipping self-improving AI agents. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
future-agi is an open-source end-to-end agent engineering and optimization platform for shipping self-improving AI agents. Unifies tracing, evals, simulations, datasets, gateway, and guardrails in one self-hostable platform. Added to Agents > Autonomous agents.