### PR TITLE
Add OpenClaw Easy under Text → Custom interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 
 - [LibreChat](https://librechat.ai/) - LibreChat is a free and open-source chat interface for assistant AIs. [#opensource](https://github.com/danny-avila/LibreChat).
 - [Chatbot UI](https://www.chatbotui.com/) - An open source ChatGPT UI. [#opensource](https://github.com/mckaywrigley/chatbot-ui).
+- [OpenClaw Easy](https://openclaw-easy.com/) - One-click signed desktop installer (macOS + Windows) that routes Claude, ChatGPT, Gemini, DeepSeek, OpenRouter or local Ollama models into WhatsApp, Telegram, Slack, Discord, Feishu and Line. 100% local — keys and messages never leave the device. [#opensource](https://github.com/openclaw-easy/openclaw-easy-desktop).
 
 ### Search engines
 


### PR DESCRIPTION
Adds OpenClaw Easy to the **Text → Custom interfaces** section, alongside LibreChat and Chatbot UI.

**What it does**

Free open-source desktop installer (macOS + Windows) that routes Claude, ChatGPT, Gemini, DeepSeek, OpenRouter or local Ollama models into messaging apps (WhatsApp, Telegram, Slack, Discord, Feishu, Line). 100% local — keys never leave the device.

**Why Custom interfaces**

Peers LibreChat and Chatbot UI are also open-source local chat front-ends for assistant models. OpenClaw Easy fits the same category but with multichannel delivery (messaging apps) instead of a web UI.

**Compliance checklist**

- [x] Format: \`[ProjectName](Link) - Description ending with period.\`
- [x] Added to bottom of Custom interfaces category
- [x] Open source (Apache-2.0) — https://github.com/openclaw-easy/openclaw-easy-desktop
- [x] Actively maintained — commits in the last 7 days
- [x] Well-documented — https://openclaw-easy.com plus blog setup guides
- [x] If follower count is below the Main List 1k threshold, please move to Discoveries — fit description is the same.
