### PR TITLE
Add AnySlide to Graphic design

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Brandmark](https://brandmark.io/) - AI-based logo design tool.
 - [Gamma](https://gamma.app/) - Create beautiful presentations and webpages with none of the formatting and design work.
 - [Microsoft Designer](https://designer.microsoft.com/) - Stunning designs in a flash.
+- [AnySlide](https://anyslide.app) - AI slide deck generator with HTML and image-rendered engines, supporting native Chinese, Japanese, and Korean text.
 
 ### Image libraries
 


### PR DESCRIPTION
Hi @steven2358! Adding **AnySlide** to the `### Graphic design` section, alongside Gamma.

### What it is
An AI slide deck generator that turns articles, links, or PDFs into a full presentation in ~30 seconds. Two rendering engines:
- **HTML path** — outputs inline-editable web slides (reveal.js / Slidev style)
- **gpt-image-2 path** — renders each page as a full image with **native Chinese / Japanese / Korean text**, solving the garbled-CJK problem that most AI image tools have with non-Latin scripts

### Quality standards
- Actively maintained, regular updates
- Public, no waitlist, 60 free credits at signup (no credit card)
- Well-documented landing + pricing pages
- Live: https://anyslide.app

### On the inclusion criteria
The project doesn't yet have 1,000+ followers (we're new), but I think it might fit the "personally interesting" criterion through:
- A novel rendering approach — using `gpt-image-2` as the slide engine rather than HTML/CSS only
- The CJK-rendering angle isn't represented elsewhere in the list — Gamma, Microsoft Designer, and Brandmark all use Latin-centric pipelines

If you'd prefer this go to `DISCOVERIES.md` instead, I'd be glad to move the entry — just let me know.

### Disclosure
I'm the maker of AnySlide. Thanks for maintaining the list!