### PR TITLE
Add Dualmark to Developer tools — open-source AEO infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [Dualmark](https://dualmark.dev/) - Open-source AEO (Answer Engine Optimization) infrastructure. Publishes a markdown twin of every web page (e.g. `/pricing` + `/pricing.md`) and serves it to AI crawlers (GPTBot, ClaudeBot, PerplexityBot, +16 more) via HTTP content negotiation, so your site shows up cleanly in AI search instead of HTML-scraped fragments. Adapters for Astro, Next.js, Cloudflare Workers. [#opensource](https://github.com/dodopayments/dualmark)
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [Dualmark](https://dualmark.dev) to **Coding → Developer tools**, next to Agentset.

**What it is:** Open-source AEO (Answer Engine Optimization) infrastructure. Publishes a markdown twin of every web page (`/pricing` + `/pricing.md`) and serves it to AI crawlers (GPTBot, ClaudeBot, PerplexityBot, +16 known UAs) via HTTP content negotiation. Same URL, two formats; humans see HTML.

Why this section: like Gitingest / Repomix (publisher-side LLM-friendly content prep tools already in this list), Dualmark is publisher-side infrastructure that makes generative AI consume content more cleanly — except instead of one-shot codebase packaging, it's an always-on adapter for production websites.

- Repo: https://github.com/dodopayments/dualmark (Apache 2.0)
- 6 npm packages (`@dualmark/{core,converters,astro,nextjs,cloudflare,cli}`)
- 313 tests, 125/125 self-conformance on dualmark.dev
- npm provenance attested (Sigstore-signed), verifiable with `npm audit signatures`
- Public RFC-2119 AEO Spec v1.0: https://github.com/dodopayments/dualmark/tree/main/spec

Happy to adjust placement or wording.