### PR TITLE
Add localaik to Local LLM Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [RunThisLLM](https://runthisllm.com) - See which LLMs you can run on your hardware.
 - [Harbor](https://github.com/av/harbor) - A containerized toolkit for running local LLM backends, UIs, and supporting services with one command. #opensource
 - [off-grid-mobile](https://github.com/alichherawalla/off-grid-mobile-ai) - React Native app for running LLMs, vision models, and Stable Diffusion on-device on iOS and Android without internet access. #opensource
+- [localaik](https://github.com/harshaneel/localaik) - LocalStack-style local emulation of OpenAI and Gemini APIs in a single Docker container; llama.cpp + Gemma 3 backend, designed for offline development and CI testing. #opensource
 
 ## Agents
 


### PR DESCRIPTION
Adds **localaik** to the Local LLM Deployment section.

localaik is a Go-based Docker container that emulates the OpenAI and Gemini APIs on a single port, backed by llama.cpp + Gemma 3. Use case is offline development and deterministic CI testing without paid-API calls or network dependencies.

- Repo: https://github.com/harshaneel/localaik
- License: MIT (`#opensource` tag applied)
- Docker Hub: https://hub.docker.com/r/gokhalh/localaik
- Already listed in [avelino/awesome-go](https://github.com/avelino/awesome-go) (Artificial Intelligence section)
- Single PR per entry, format matches section convention.