### PR TITLE
Add Dakera — self-hosted MCP-native agent memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted MCP-native agent memory server giving AI agents persistent, decay-weighted episodic memory via 83 MCP tools. RocksDB + HNSW, 87.8% LoCoMo benchmark, zero cloud dependency. [#opensource](https://github.com/dakera-ai/dakera-mcp)
 
 ### Playgrounds
 


### PR DESCRIPTION
## Add Dakera to Developer tools

**[Dakera](https://github.com/dakera-ai/dakera-mcp)** is an open-source self-hosted agent memory server — the infrastructure layer that gives AI agents persistent, decay-weighted long-term memory.

### Why it fits Developer tools
Developers building generative AI applications need their agents to remember across sessions. Dakera provides a dedicated memory backend via 83 MCP tools, deployable locally in minutes with Docker Compose.

- **83 MCP tools** for agent memory operations
- **Decay-weighted vector recall** — memories fade by importance
- **87.8% LoCoMo benchmark** for long-term conversational memory
- **RocksDB + HNSW** Rust backend
- **Docker Compose deployment** with MinIO + Prometheus
- **Apache-2.0**, fully self-hosted