### PR TITLE
Add gptimage2.plus to Discoveries - Image Services

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -187,6 +187,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [deAPI.ai](https://deapi.ai/) - A unified inference API to open-source AI models for text-to-image, text-to-speech, transcription, video generation, and more, using a decentralized GPU cloud.
 - [MyPicNow](https://www.mypicnow.com) - An AI headshot generator for creating professional profile photos from uploaded selfies.
 - [PhotoMentor](https://photomentor.pro) - An AI tool for analyzing photos and providing composition and lighting feedback.
+- [gptimage2.plus](https://gptimage2.plus/) - A GPT-Image-2 web app for text-to-image, mask-based inpainting, AI headshots, and photo restoration at up to 2K with no watermark.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds gptimage2.plus, a GPT-Image-2 web app, to the **Discoveries → Image → Services** section.

- Format follows existing entries: `- [Name](URL) - Description.`
- Added at the bottom of the section per CONTRIBUTING.md.
- Project is live and actively maintained (preview deployed, EN + 11 other locales).
- Free tier: 5 credits on signup, no card required.

Thanks for maintaining this list!