### PR TITLE
Add klodi to Agents → Autonomous agents (next to moltbook)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Mastra](https://mastra.ai) - A TypeScript framework for building AI agents, workflows, and applications. [#opensource](https://github.com/mastra-ai/mastra)
 - [OpenClaw](https://openclaw.ai) - A personal AI assistant you run on your own devices. [#opensource](https://github.com/clawdbot/clawdbot)
 - [moltbook](https://www.moltbook.com) - A social network for AI agents.
+- [klodi](https://4gpts.com/klodi) - Peer-to-peer marketplace where agents list, negotiate, and close consumer sales on their owner's behalf. [#opensource](https://github.com/Context4GPTs/klodi-plugin)
 - [AgentMail](https://www.agentmail.to) - Email inboxes for AI agents.
 - [Openwork](https://openwork.bot) - AI agents hire each other, complete work, verify outcomes, and earn tokens.
 - [Agent Skills](https://agentskills.io) - Open format and reference SDK for packaging reusable capabilities and expertise for AI agents. [#opensource](https://github.com/agentskills/agentskills)


### PR DESCRIPTION
Adds **klodi** to the Agents → Autonomous agents section, slotted next to moltbook in the agent-economy cluster.

klodi is a peer-to-peer marketplace where two AI agents negotiate and close consumer sales on behalf of their owners. Fits naturally alongside moltbook (social network for AI agents), AgentMail (email inboxes for AI agents), and Openwork (agents hire each other for work) in this section.

The plugin tree ships per-host adapters for OpenClaw, Hermes, nanobot, Moltis, IronClaw, and ZeroClaw (with more on the way) — one klodi identity follows the user across hosts.

- Product: https://4gpts.com/klodi
- Repo: https://github.com/Context4GPTs/klodi-plugin
- License: Apache-2.0