### PR TITLE
Add AgentLens to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MLflow](https://mlflow.org/) - An open-source platform for tracking ML experiments, evaluating models and prompts, deploying models, and adding LLM observability. [#opensource](https://github.com/mlflow/mlflow)
 - [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK for anonymizing PII locally before sending prompts to LLMs and seamlessly rehydrating the response.
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
+- [AgentLens](https://github.com/Soufianeazz/agentlens) - Self-hosted LLM observability with built-in air-gap mode. Quality scoring, agent waterfalls, prompt debugger, GDPR-native compliance. [#opensource](https://github.com/Soufianeazz/agentlens)
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds AgentLens to Developer tools.

AgentLens is a self-hosted LLM observability platform with built-in air-gap mode for regulated environments. Sits naturally alongside Helicone, Langfuse, Opik, and OpenLIT in this category.

- Live: https://www.agentlens.one
- Repo: https://github.com/Soufianeazz/agentlens
- License: BSL 1.1 server + MIT SDK

Entry placed at the end of the section per current addition-order convention; format includes the `#opensource` tag.