### PR TITLE
Add AgentTier to Discoveries (Coding/Developer tools)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -144,6 +144,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AI/ML API](https://aimlapi.com/) - Unified API for accessing multiple AI models across text, image, audio, and video.
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
+- [AgentTier](https://github.com/agenttier/agenttier) - Kubernetes-native platform that provisions isolated, persistent sandboxes for human developers and AI coding agents through a Sandbox CRD, with a streaming agent-mode REST API. [#opensource](https://github.com/agenttier/agenttier)
 
 ### Playgrounds
 


### PR DESCRIPTION
This PR adds [AgentTier](https://github.com/agenttier/agenttier) to **DISCOVERIES.md → Coding → Developer tools**.

AgentTier is a Kubernetes-native platform that provisions isolated, persistent sandboxes for both human developers and AI coding agents through a single `Sandbox` CRD. Each sandbox is a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation. It supports both interactive use (browser terminal over WebSocket) and headless agent workloads (REST `/configure` to install code, then SSE-streaming `/invoke` to run). Reference templates ship for Claude Code + Bedrock and a model-free LangGraph agent. Apache-2.0.

**Targeting Discoveries (not Main List):** AgentTier doesn't yet have 1,000 followers, so it's submitted to the Discoveries list per CONTRIBUTING.md. The peer set in **Developer tools** (Stacklok, Lunary, Simplismart, GPTRouter) is exactly the right one — platform/infra projects for AI agents and LLMs.

**Compliance with CONTRIBUTING.md:**

- ✅ Format: `[ProjectName](Link) - Description.` with period at end.
- ✅ Added at the bottom of the **Developer tools** category, per the rule.
- ✅ Concise, clear, straightforward description.
- ✅ Quality: actively maintained (last release v0.3.0 yesterday), well-documented (mkdocs site at https://agenttier.github.io/agenttier/), Apache-2.0.
- ✅ No trailing whitespace.
- ✅ Single-line diff.

Disclosure: I'm a contributor to AgentTier.
