### PR TITLE
Add Punch Needle Generator to Image > Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Reve Image](https://reve.com/) - A model trained from the ground up to excel at prompt adherence, aesthetics, and typography.
 - [Magnific](https://www.magnific.com/) - AI-powered design tools including image generation, background removal, and creative templates.
 - [FigureLabs](https://www.figurelabs.ai/) - An AI tool for generating publication-ready scientific figures in vector format from text descriptions or sketches.
+- [Punch Needle Generator](https://www.punchneedle.co.il/en) - AI-powered punch needle embroidery pattern generator with color-coded yarn maps from text prompts or image uploads.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds Punch Needle Generator under **Image > Services**.

- **Name:** Punch Needle Generator
- **URL:** https://www.punchneedle.co.il/en
- **Description:** AI-powered punch needle embroidery pattern generator with color-coded yarn maps from text prompts or image uploads.

Notes per CONTRIBUTING:
- Added to the bottom of the Services category, format `[Name](URL) - Description.` with period.
- Niche application of generative AI for image-to-pattern conversion - maintainer's call whether it fits the Main List or the Discoveries list.
- I'm the maintainer of the tool.