### PR TITLE
Add XFMS — hosted MCP for LLM model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Meta's LLaMA model (and others) in pure C/C++. #opensource
 - [bitnet.cpp](https://github.com/microsoft/BitNet) - Official inference framework for 1-bit LLMs, by Microsoft. [#opensource](https://github.com/microsoft/BitNet)
 - [OpenRouter](https://openrouter.ai/) - A unified interface for LLMs. [#opensource](https://github.com/OpenRouterTeam)
+- [XFMS](https://github.com/VisionAIrySE/XFMS) - Pick the right LLM for any stated task. Aggregates evidence from 8 independent benchmark sources and returns a ranked shortlist with plain-English rationale per pick. [#opensource](https://github.com/VisionAIrySE/XFMS)
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource


### PR DESCRIPTION
Adds [XFMS](https://github.com/VisionAIrySE/XFMS) to the Developer tools section.

XFMS is a hosted MCP server that picks the right LLM for any stated task. It aggregates evidence from 8 independent third-party benchmark sources (no provider self-reports), infers which quality dimensions matter from the stated purpose, and returns a ranked shortlist with plain-English rationale per pick.

Install in one line: `claude mcp add xfms --transport http https://xfms.vercel.app/mcp/`

Part of the [Xpansion Framework](https://xpansion.dev).