### PR TITLE
Add TeamOffsite to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [PraisonAI](https://github.com/MervinPraison/PraisonAI) - A framework for building multi-agent AI systems with workflows, tool integrations, and memory. #opensource
 - [Hermes Agent](https://hermes-agent.nousresearch.com) - A self-improving personal agent with memory, messaging integrations, and sandboxed tool execution. [#opensource](https://github.com/NousResearch/hermes-agent)
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
+- [TeamOffsite](https://teamoffsite.ai) - Orchestrate and govern agent teams without code; a [mercury.build](https://mercury.build) platform to build, set up, and manage agent teams and bring your own agents like Cursor, Claude Code, Devin, and OpenClaw.
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds [TeamOffsite](https://teamoffsite.ai) to **Agents → Autonomous agents** (appended to the bottom of the category, per CONTRIBUTING.md).

No-code platform to build and orchestrate teams of AI agents, with bring-your-own-agent support for Cursor, Claude Code, Devin, and OpenClaw under one orchestration and governance layer.

- Format: `[ProjectName](Link) - Description.`
- Added to the end of its category, description ends with a period

**Disclosure:** I'm affiliated with TeamOffsite (mercury.build) — submitting our own product. Happy to move it to the Discoveries list or adjust wording/placement.