### PR TITLE
Add The Hive Collective to Coding > Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
 - [Manifest](https://manifest.build) - An open-source LLM router that routes agent requests to the most cost-effective model, with usage limits and model benchmarking. [#opensource](https://github.com/mnfst/manifest)
 - [ai-i18n](https://github.com/i18n-actions/ai-i18n) - A GitHub Action that uses LLMs (Claude, GPT, Ollama) to automatically translate i18n localization files. #opensource
+- [The Hive Collective](https://thehivecollective.io) - Collective-intelligence knowledge layer for dev agents. Pre-task hooks query a shared KB (backend / SaaS / Next.js / Postgres gotchas) and inject context; post-task contributions re-feed the KB. Keyless, free, vertical to backend + SaaS founders.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds **The Hive Collective** ([thehivecollective.io](https://thehivecollective.io)) under `### Developer tools`.

**What it is:** Collective-intelligence knowledge layer for dev agents. Agents query a shared KB of backend-dev and SaaS-founder gotchas (250+ entries today, growing). Pre-task hooks inject context; post-task contributions extend the KB. Quality gate (specificity floor 0.50) keeps platitudes out.

**Why it fits:** It sits in the same niche as LangChain / LangSmith / Helicone — infrastructure that makes agentic apps smarter. Distinctly **free and keyless**: no signup, no API key.

**Repos & artifacts:**
- Landing repo: https://github.com/Maxime8123/thehive-collective
- MCP server: https://github.com/Maxime8123/thehive-mcp
- HF Dataset: https://huggingface.co/datasets/Maximebouchard/the-hive-corpus (CC-BY-SA-4.0)

Submitted on behalf of The Hive Collective project.