### PR TITLE
Add QuickSilver Pro to Discoveries (Text > Models)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -27,6 +27,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 ### Models
 
 - [SambaNova](https://sambanova.ai/) - Full stack generative AI platform, from chip to model, designed for enterprise and government entities and powered by a dataflow architecture.
+- [QuickSilver Pro](https://quicksilverpro.io/) - An OpenAI-compatible inference API for open-weight LLMs such as DeepSeek, Qwen, and Kimi, plus the Google Gemini family.
 
 ### Chatbots
 


### PR DESCRIPTION
Adds QuickSilver Pro to the Discoveries list under **Text > Models**.

QuickSilver Pro is an OpenAI-compatible inference API for open-weight LLMs (DeepSeek, Qwen, Kimi) and the Google Gemini family.

Entry follows the existing format (`[Name](Link) - Description.`) and is appended to the bottom of the category, per CONTRIBUTING.md. Placed in Discoveries since it is a service rather than a repo meeting the Main List follower threshold.

Disclosure: I'm with QuickSilver Pro.