### PR TITLE
Add AI Models Catalog — 4,587+ models across 95 providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Qwen](https://qwenlm.github.io/) - A series of LLMs independently developed by Alibaba Cloud. [#opensource](https://github.com/QwenLM/Qwen)
 - [DeepSeek](https://huggingface.co/deepseek-ai) - DeepSeek V3 and R1 series of LLMs by DeepSeek AI. [#opensource](https://github.com/deepseek-ai)
 - [MiniMax](https://www.minimax.io/) - Multimodal foundation models for text, speech, video, and music generation
+- [AI Models Catalog](https://github.com/i-need-token/ai-models) - Structured catalog of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities. First-party data with TypeScript types and Zod validation. #opensource
 
 ### Chatbots
 


### PR DESCRIPTION
## Addition

**AI Models Catalog** — A structured catalog of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities. All data sourced from first-party APIs with TypeScript types and Zod validation.

### Why this fits
- **First-party data** — pricing, context windows, and capabilities verified against official provider APIs
- **Comprehensive** — 95 providers including OpenAI, Anthropic, Google, Meta, DeepSeek, Mistral, xAI, and 88 more
- **Structured** — YAML format with TypeScript types and Zod runtime validation
- **Useful** — interactive catalog with search, filter, compare, export, price calculator, and model picker
- **Open source** — MIT licensed, community contributions welcome

### Links
- Repository: https://github.com/i-need-token/ai-models
- Interactive catalog: https://i-need-token.github.io/ai-models/
- npm package: ai-models

Added to the **Text > Models** section alongside OpenAI, Claude, Llama, Mistral, etc.