### PR TITLE
Add career-ops to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Open Notebook](https://www.open-notebook.ai) - An open source implementation of NotebookLM with more flexibility and features. [#opensource](https://github.com/lfnovo/open-notebook)
 - [Screenpipe](https://github.com/screenpipe/screenpipe) - An open-source tool for recording screen and audio activity with AI-powered search, automations, and support for local LLMs. #opensource
 
+- [career-ops](https://github.com/santifer/career-ops) - AI-powered job search orchestrator built on Claude Code. 14-skill pipeline that evaluates jobs, generates ATS-tailored PDFs, and tracks applications end-to-end on the candidate side. Local-first, MIT. #opensource
+
 ### Meeting assistants
 
 - [Otter.ai](https://otter.ai/) - A meeting assistant that records audio, writes notes, automatically captures slides, and generates summaries.


### PR DESCRIPTION
Adds [career-ops](https://github.com/santifer/career-ops) to the Productivity section.

## What it is
AI-powered job search orchestrator built on Claude Code. 14-skill pipeline that evaluates job descriptions, generates ATS-tailored PDFs, and tracks applications end-to-end. Local-first (CV never leaves the machine), MIT licensed.

## Why it fits the Productivity category
career-ops is a productivity tool for the candidate side of hiring — it automates the most time-consuming parts of the job search (evaluating fit, tailoring CVs, batching outreach, tracking applications) so candidates can spend their time on actual interview prep and outreach decisions.

## Inclusion criteria (per CONTRIBUTING)
- ✅ "Widely used and useful" — 46,422 GitHub stars (top 500 repos worldwide), 9,705 forks, 3,167 Discord members
- ✅ "Actively maintained" — 55 contributors, regular commits, active community
- ✅ "Well-documented" — full README, 14 documented skill modes, dedicated docs at https://career-ops.org
- ✅ Main list criterion #1: "≥1,000 followers/stars" — 46K passes by 46×

## Format
Followed exact format: `[Name](Link) - Description.`, ending with period, `#opensource` marker matching other entries (e.g. Screenpipe pattern). Added at the bottom of the Productivity section per CONTRIBUTING guideline.

Thanks for maintaining this list.