### PR TITLE
Add LLM Reference to Leaderboards section

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenRouter LLM Rankings](https://openrouter.ai/rankings) - Language models ranked and analyzed by usage across apps.
 - [SEAL LLM Leaderboard](https://labs.scale.com/leaderboard) - Expert-driven LLM benchmarks and updated AI model leaderboards.
 - [LLM Stats](https://llm-stats.com/) - Compare AI models across benchmarks, pricing, speed, and context window.
+- [LLM Reference](https://www.llmreference.com/) - Benchmark-backed, price-aware directory comparing 1,700+ LLM models across 130+ providers, updated daily.
 
 ### Other text generators
 


### PR DESCRIPTION
Adds [LLM Reference](https://www.llmreference.com/) to the **Text → Leaderboards** subsection.

LLM Reference is a free, benchmark-backed directory comparing 1,700+ LLM models across 130+ providers, with daily-updated pricing, context windows, and benchmark scores. It fits alongside existing entries like Artificial Analysis, OpenRouter LLM Rankings, and LLM Stats.

**Disclosure:** I'm affiliated with the site. Happy to revise wording or move the entry if a different section fits better.