### PR TITLE
Add CLAWVR to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [NotebookLM](https://notebooklm.google/) - A research and note-taking online tool to interact with documents, powered by Google Gemini.
 - [Open Notebook](https://www.open-notebook.ai) - An open source implementation of NotebookLM with more flexibility and features. [#opensource](https://github.com/lfnovo/open-notebook)
 - [Screenpipe](https://github.com/screenpipe/screenpipe) - An open-source tool for recording screen and audio activity with AI-powered search, automations, and support for local LLMs. #opensource
+- [CLAWVR](https://clawvr.com) - A productized service that generates custom AI Operating Systems for small businesses (master prompts + workflow superprompts + 30-day rollout), with open-source assets including a [Claude Agent Skill](https://github.com/Steffd415/clawvr-agent-skill), an [MCP server](https://github.com/Steffd415/clawvr-mcp-server), and [25+ vertical playbooks](https://github.com/Steffd415/awesome-claude-prompts-for-smb). #opensource
 
 ### Meeting assistants
 


### PR DESCRIPTION
## What this adds

A single line to the **Productivity** section under **Text**:

```
- [CLAWVR](https://clawvr.com) - A productized service that generates custom AI Operating Systems for small businesses (master prompts + workflow superprompts + 30-day rollout), with open-source assets including a [Claude Agent Skill](https://github.com/Steffd415/clawvr-agent-skill), an [MCP server](https://github.com/Steffd415/clawvr-mcp-server), and [25+ vertical playbooks](https://github.com/Steffd415/awesome-claude-prompts-for-smb). #opensource
```

## Why it fits

CLAWVR is a productized generative-AI service targeting small business operators. It uses Claude/ChatGPT/Gemini to generate:
- A master system prompt that teaches the AI about the buyer's industry, tools, and team
- 18 workflow superprompts (lead response, follow-up, review collection, etc.)
- A 30-day rollout roadmap

The three linked open-source repos are MIT licensed and actively maintained.

## Inclusion criteria

- [x] **Open-source companion repos** at github.com/Steffd415 (master prompts, Agent Skill, MCP server) — combined ~80 stars and growing
- [x] **Active maintenance** — repos pushed within the last 24 hours
- [x] **Well-documented** — each repo has a comprehensive README with install + example walkthroughs
- [x] **Original work** — not a fork or wrapper of an existing project; the productized service + the three open-source companion repos are new in 2026

If the project doesn't meet the main-list criteria, happy to move the entry to the Discoveries list. Thanks for considering!