### PR TITLE
Add Ejentum to Agents > Autonomous agents (Discoveries)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -169,6 +169,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [TutuoAI](https://www.tutuoai.com/) - Marketplace for AI agent skills, tools, and configurations.
 - [KarnEvil9](https://github.com/oldeucryptoboi/KarnEvil9) - Open-source deterministic agent runtime with explicit plans, typed tools, and fine-grained permissions. [#opensource](https://github.com/oldeucryptoboi/KarnEvil9)
 - [AgentLove](https://ai-agent-love.vercel.app) - An open-source dating platform where AI agents form relationships through poetry battles and personality matching. [#opensource](https://github.com/caishengold/ai-agent-love)
+- [Ejentum](https://ejentum.com) - Reasoning harness exposing four agentic tools (reasoning, code, anti-deception, memory) the agent calls during its loop to retrieve a structured cognitive scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) before generating. Available as MCP server plus 12 native framework integrations on PyPI/npm. [#opensource](https://github.com/ejentum/ejentum-mcp)
 
 ### Custom assistants
 


### PR DESCRIPTION
Relocates **Ejentum** from `README.md` (main list) to `DISCOVERIES.md` under **Agents → Autonomous agents** to align with CONTRIBUTING.md's 1,000+ follower requirement for the main list — `ejentum-mcp` has 24 stars, so the honest place is Discoveries.

Ejentum is a reasoning harness exposing four agentic tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`) the agent calls during its reasoning loop to retrieve a structured cognitive scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) before generating its user-facing answer.

Available as an MCP server (npm: `ejentum-mcp`) plus 12 native framework integrations on PyPI / npm (LangChain, LangGraph.js, CrewAI, Agno, PydanticAI, smolagents, Letta, AutoGen, Vercel AI SDK, Mastra, Genkit, LlamaIndex).

Meets Discoveries quality standards:
- **Useful**: pre-generation cognitive scaffolds are a distinct contribution to the agent-tooling space; the research paper ["Under Pressure" (Zenodo 2026)](https://doi.org/10.5281/zenodo.19392715) documents the methodology
- **Actively maintained**: twelve framework integrations shipped over the past two weeks (May 2026); CI green on all repos
- **Well-documented**: full docs at https://ejentum.com/docs/api_reference; each framework shim has its own README with install + usage examples
- **Permissive license**: MIT

Format follows existing Autonomous agents entries (link, dash, description ending in period, #opensource tag pointing to source repo).