### PR TITLE
Add Gemini Omni Prompts — source-cited library for Google's new video model

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Google Flow](https://labs.google/fx/tools/flow) - An AI filmmaking tool from Google, powered by Veo.
 - [Seedance 2.0](https://seed.bytedance.com/en/seedance2_0) - An image-to-video and text-to-video model developed by Niobotics ByteDance.
 - [MaxVideoAI](https://maxvideoai.com/examples) - A workspace for generating and comparing videos across multiple AI video models.
+- [Gemini Omni Prompts](https://geminiomniprompts.org/) - Source-cited prompt library for Google's Gemini Omni video model. Free, no signup.
 
 ### Avatars
 


### PR DESCRIPTION
## What this adds

Adds [Gemini Omni Prompts](https://geminiomniprompts.org/) — a free, source-cited prompt library for Google's Gemini Omni video model (released May 2026).

## Why it might fit here

Every prompt is adapted from a verifiable source rather than AI-guessed:
- DeepMind's official prompt guide (e.g. the mirror-ripple, butterfly→bee, bubble sculpture demos)
- Hands-on testing from PixVerse, Atlas Cloud, Chrome Unboxed, and Medium's "Gemini Omni Prompt Playbook"

There's also a field guide covering Omni's prompt formula, camera vocabulary it explicitly parses, duration sweet spots per use case, and known failure modes Google's docs don't surface (text rendering, hand articulation, multi-shot consistency, prompt length).

No login, no API key, no upsell. Static site (Astro + Cloudflare Pages).

## Checklist

- [x] One link per PR
- [x] Placed under the most relevant existing category (Video)
- [x] Format matches surrounding entries