### PR TITLE
Add NovAI - unified API platform for Chinese LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Meta's LLaMA model (and others) in pure C/C++. #opensource
 - [bitnet.cpp](https://github.com/microsoft/BitNet) - Official inference framework for 1-bit LLMs, by Microsoft. [#opensource](https://github.com/microsoft/BitNet)
 - [OpenRouter](https://openrouter.ai/) - A unified interface for LLMs. [#opensource](https://github.com/OpenRouterTeam)
+- [NovAI](https://aiapi-pro.com) - A unified API platform for Chinese LLMs including DeepSeek, Qwen, and GLM, with OpenAI-compatible endpoints.
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource


### PR DESCRIPTION
Add [NovAI](https://aiapi-pro.com) under Developer tools. NovAI provides a unified OpenAI-compatible API for Chinese LLMs including DeepSeek, Qwen, and GLM, similar to OpenRouter but focused on Chinese model providers.