### PR TITLE
Add linkedin2md: LinkedIn data exports to Markdown for LLM analysis

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -85,6 +85,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [SageCollab](https://sagecollab.com/) - SageCollab brings team collaboration features to generative AI.
 - [Worksheets.ai](https://www.worksheets.ai/) - Generate educational worksheets and lesson plans with AI.
 - [Recall](https://www.recall.it/) - A self-organizing knowledge base, where you can summarize and chat with any online content.
+- [linkedin2md](https://github.com/juanmanueldaza/linkedin2md) - Convert LinkedIn data exports to Markdown for LLM analysis and PDF resume generation.
 
 ### Meeting assistants
 - [Goelo](https://www.goelo.com/) - Goelo helps sales teams automatically fill their CRM by recording meetings to create summaries and generate a knowledge base.


### PR DESCRIPTION
## linkedin2md

**GitHub:** https://github.com/juanmanueldaza/linkedin2md
**PyPI:** https://pypi.org/project/linkedin2md/

A zero-dependency Python CLI that converts LinkedIn ZIP data exports into clean, structured Markdown — ideal for feeding career data into LLMs (Ollama, LM Studio, NotebookLM, Claude Projects, ChatGPT) and generating ATS-optimized PDF resumes.

### Why it fits in Generative AI Discoveries

- **LLM data preparation tool**: Converts raw LinkedIn exports (HTML/CSV) into LLM-ready Markdown — the exact format LLMs and RAG systems consume best
- **Zero dependencies, fully local**: No API keys, no cloud, no data leaves your machine
- **PDF resume generation**: Built-in ATS-optimized PDF output from LinkedIn data
- **Part of a data-to-Markdown pipeline**: [github2md](https://github.com/juanmanueldaza/github2md) and [gitlab2md](https://github.com/juanmanueldaza/gitlab2md) cover GitHub and GitLab profiles

While the project currently has 14 GitHub stars, it fills a unique niche in the GenAI ecosystem: turning personal career data into structured context for AI tools.