### PR TITLE
Add ComfyStudio to Image > Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Reve Image](https://reve.com/) - A model trained from the ground up to excel at prompt adherence, aesthetics, and typography.
 - [Magnific](https://www.magnific.com/) - AI-powered design tools including image generation, background removal, and creative templates.
 - [FigureLabs](https://www.figurelabs.ai/) - An AI tool for generating publication-ready scientific figures in vector format from text descriptions or sketches.
+- [ComfyStudio](https://comfystudio.io/) - A browser-based AI illustration and short-video studio for anime and illustration creators. Runs curated ComfyUI / fal.ai workflows with no install or GPU required.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds ComfyStudio (https://comfystudio.io/) to the Image > Services section.

ComfyStudio is a browser-based AI illustration and short-video studio that runs 27 curated ComfyUI / fal.ai workflows with no install or local GPU required. It specializes in anime and illustration use cases and is positioned as safe-for-work (no NSFW or real-person manipulation).

- Free tier: 100 credits at signup, no credit card required
- 13 image styles + 9 video models + 5 image-edit pipelines
- Commercial use allowed on all plans

Self-disclosure: I'm the founder of ComfyStudio. Happy to remove or adjust the description if anything doesn't fit the list's style guide.

Contribution guidelines respected:
- [x] One project per PR
- [x] Description includes a short value-add beyond the name