### PR TITLE
Add Spanlens to Developer tools (Discoveries)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -148,6 +148,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
+- [Spanlens](https://github.com/spanlens/Spanlens) - Open-source LLM observability platform with drop-in OpenAI/Anthropic/Gemini proxy for cost tracking, agent tracing, and anomaly detection. Self-hostable via Docker. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [Spanlens](https://github.com/spanlens/Spanlens) to the **Developer tools** subsection of `DISCOVERIES.md`.

**What it is:** Open-source LLM observability platform. Drop-in OpenAI / Anthropic / Gemini / Azure / Ollama baseURL replacement that records every call with cost, latency, tokens, traces, anomaly detection, PII scan, and prompt-version A/B testing. Self-hostable via Docker.

**Why Discoveries (not Main List):** Spanlens currently has under 1,000 GitHub stars, so per the inclusion criteria it belongs in the Discoveries list rather than the main one. Happy to migrate later if it crosses the threshold.

**Format check:**
- [x] `[Name](URL) - Description.` format ending with a period
- [x] Added to the bottom of the existing `Developer tools` category (after EvoLink)
- [x] `#opensource` tag included (MIT licensed)
- [x] Concise description matching peer entries (Lunary, Fiddler.ai)
- [x] Actively maintained, well-documented