### PR TITLE
Add AgentHUD — game-style HUD overlay for AI agent observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Manifest](https://manifest.build) - An open-source LLM router that routes agent requests to the most cost-effective model, with usage limits and model benchmarking. [#opensource](https://github.com/mnfst/manifest)
 - [ai-i18n](https://github.com/i18n-actions/ai-i18n) - A GitHub Action that uses LLMs (Claude, GPT, Ollama) to automatically translate i18n localization files. #opensource
 
+- [AgentHUD](https://github.com/IAMMARBIT/AgentHUD) - Game-style HUD overlay for AI agent observability. Live animated cards per agent showing tool calls, tokens, cost, latency, success rate, and a sparkline. Drop-in adapters for LangChain, OpenAI Agents SDK, Claude Agent SDK, CrewAI, and AutoGen. 14 polished skins + community skin marketplace. [#opensource](https://github.com/IAMMARBIT/AgentHUD)
+
 ### Playgrounds
 
 - [OpenAI Playground](https://platform.openai.com/playground) - Explore resources, tutorials, API docs, and dynamic examples.


### PR DESCRIPTION
Adding [AgentHUD](https://github.com/IAMMARBIT/AgentHUD) under **Coding → Developer tools** (next to LLM-observability peers like Helicone, Langfuse, Opik, MLflow).

Differentiator from those: game-HUD aesthetic on the desktop (not a web dashboard). Drop-in adapters for the 5 major agent frameworks (LangChain, OpenAI Agents SDK, Claude Agent SDK, CrewAI, AutoGen) with 3-line installs. Ships 14 polished skins + community skin marketplace. MIT, localhost-only, no telemetry. Just-launched v0.2.0.