### PR TITLE
Add Inference Labs to Developer tools (next to OpenRouter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Meta's LLaMA model (and others) in pure C/C++. #opensource
 - [bitnet.cpp](https://github.com/microsoft/BitNet) - Official inference framework for 1-bit LLMs, by Microsoft. [#opensource](https://github.com/microsoft/BitNet)
 - [OpenRouter](https://openrouter.ai/) - A unified interface for LLMs. [#opensource](https://github.com/OpenRouterTeam)
+- [Inference Labs](https://inference-labs.com) - Vendor-neutral router for the major cloud LLMs (OpenAI/Azure, Anthropic, Google, AWS Bedrock) with policy-based routing, semantic caching, eval suites, and trace pipelines. Python SDK + LangChain adapter. [#opensource](https://github.com/bosslesss/inference-labs-python)
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource


### PR DESCRIPTION
Hi! Suggesting a single-line addition right below OpenRouter in Developer tools. [Inference Labs](https://inference-labs.com) is a vendor-neutral router for the major cloud LLMs that adds policy-based model selection, semantic caching, eval suites, and JSONL export of production traces.

Open-source Python SDK: https://github.com/bosslesss/inference-labs-python (Apache-2.0), includes a LangChain `ChatInferenceLabs` adapter.

Happy to move/reword if you'd prefer.