### PR TITLE
Add brain.md to DISCOVERIES (Developer tools)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -148,6 +148,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
+- [brain.md](https://github.com/mi4uu/brain.md) - Local-first markdown vault with a built-in MCP server: 16 tools for Claude Code, Claude Desktop and any MCP agent (semantic_outline, context_for_query, find_orphans, weekly_digest, compare_notes, plus the usual read/write/search/tasks). Per-folder agent permissions, LanceDB vectors, swappable embedder (Xenova ONNX / Ollama / OpenAI). Single Bun binary. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adding **[brain.md](https://github.com/mi4uu/brain.md)** to **DISCOVERIES → Developer tools**.

> ⚠️ Per [CONTRIBUTING.md](CONTRIBUTING.md), the project doesn't yet meet the 1000-follower threshold for the Main List, so I'm submitting to Discoveries as instructed.

### What it is

Local-first markdown vault with a built-in MCP server. 16 MCP tools give Claude Code / Claude Desktop / Cursor / any MCP agent native read/write/search access to a plain folder of `.md` files, plus agent-shaped tools that go beyond CRUD (`context_for_query` for token-budgeted chunk packing, `find_orphans` for notes with zero backlinks and low semantic neighbour density, `weekly_digest` for topic clusters, `compare_notes`, `semantic_outline`, `find_similar_tasks` filtered by open/done/all).

Per-folder agent permissions (`{read, write}` walks the parent chain, nearest override wins) so you can keep `Journal/Private/` out of agent reach without locking the whole vault.

### Stack

Bun + Elysia + React 18 + CodeMirror 6 + LanceDB + `@modelcontextprotocol/sdk` (stateless streamable HTTP transport). Default embedder is `bge-small-en-v1.5` via Xenova ONNX, swappable to Ollama / LM Studio / OpenAI. Single Bun binary, no Electron. AGPL-3.0-or-later.

Entry follows the `[Name](URL) - Description.` format with `#opensource` tag, placed at the bottom of the **Developer tools** category as instructed.