### PR TITLE
Add Extypis to Writing assistants

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -67,6 +67,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [LogicBalls](https://logicballs.com/) - An AI writing tool for generating blog posts, ads, emails, and social media content. Includes a prompt library.
 - [Publish7](https://publish7.com/) - Agentic platform for digital marketing.
 - [WordLift Agent](https://wordlift.io/agent/) - AI agent for SEO tasks such as product descriptions, internal linking, and SERP analysis.
+- [Extypis](https://extypis.app) - All-in-one AI writing studio for novelists, essayists, and poets with project-aware AI, French- and English-language analysis, and multi-format export.
 
 ### ChatGPT extensions
 


### PR DESCRIPTION
Adding [Extypis](https://extypis.app) to the **Writing assistants** section of the Discoveries list.

**What it is**: An all-in-one AI writing studio for novelists, essayists, academic writers and poets. Combines outline editor, project-aware AI (rewrite, continue, ghost completion, scene generation that sees the entire project), French- and English-language analysis (readability, syllables/meter, repetitions, passive voice), and multi-format export (PDF, DOCX, EPUB, LaTeX, Markdown, HTML) with academic citations and footnotes.

**Stack**: Built solo (indie) with Next.js 15, Claude Sonnet 4.6, Mistral, Flux 1.1 Pro. RGPD-compliant, local-first architecture, no training on user data.

**Live**: https://extypis.app (free tier: 50 AI credits/month, no credit card)

I confirmed the entry:
- Follows the formatting (\`- [Name](URL) - Description.\`)
- Is added at the bottom of the existing **Writing assistants** category
- Description is concise and ends with a period
- No trailing whitespace