### PR TITLE
Add GenOps Framework to Developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -149,6 +149,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
+- [GenOps Framework](https://github.com/neerazz/genops-framework) - A governance-first framework for embedding generative AI agents into CI/CD pipelines with risk scoring, autonomy gates, canary rollouts, and immutable audit trails. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adding **GenOps Framework** to the Developer tools section of the Discoveries list.

- Open-source (MIT): https://github.com/neerazz/genops-framework
- A governance-first framework for embedding generative AI agents into CI/CD pipelines — risk scoring, autonomy gates, canary rollouts, and immutable audit trails.
- Fits alongside the other AI dev/ops governance tools in this category (Lunary, Fiddler, Agentic Radar).

Entry follows the `[ProjectName](Link) - Description.` format and is appended to the bottom of the category per CONTRIBUTING. Happy to adjust wording or placement if useful. Thanks for maintaining this list!