### PR TITLE
Add FunASR to Speech-to-text section

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Vibe Transcribe](https://thewh1teagle.github.io/vibe/) - All-in-one solution for effortless audio and video transcription. [#opensource](https://github.com/thewh1teagle/vibe)
 - [whisper.cpp](https://github.com/ggml-org/whisper.cpp) - Port of OpenAI's Whisper model in C/C++. #opensource
 - [whisper-ctranslate2](https://github.com/Softcatala/whisper-ctranslate2) - A Whisper CLI client compatible with the original OpenAI client, using CTranslate2 for faster inference. [#opensource](https://github.com/Softcatala/whisper-ctranslate2)
+- [FunASR](https://www.funasr.com) - Industrial-grade speech recognition toolkit supporting 50+ languages with built-in VAD, punctuation restoration, speaker diarization, and emotion detection. 170× realtime on GPU. [#opensource](https://github.com/modelscope/FunASR)
+- [SenseVoice](https://github.com/FunAudioLLM/SenseVoice) - Ultra-fast non-autoregressive speech recognition model (234M params) with speech emotion recognition and audio event detection. 15× faster than Whisper-large. #opensource
 
 ### Music
 


### PR DESCRIPTION
Adds [FunASR](https://github.com/modelscope/FunASR) and [SenseVoice](https://github.com/FunAudioLLM/SenseVoice) to the Speech-to-text section.

FunASR is an industrial-grade speech recognition toolkit featuring:
- **170x realtime** inference speed with SenseVoice model
- **50+ language** support
- Built-in VAD, punctuation restoration, speaker diarization, and emotion detection
- OpenAI-compatible API server
- MIT licensed

## Current-main refresh

- merged current `main@5382f00a4b44587a7e894b15d6bd12c769a57acb` without rewriting the listing commit
- preserved the new upstream NeMo and Parakeet entries while retaining the FunASR and SenseVoice entries
- current SSH-signed and GitHub-verified head: `4a3b2a6ba1025f0c3f28b19f732a0a5c7c5d69e0`
- final diff against current main is exactly two README additions; each entry occurs once and `git diff --check` passes
- `https://www.funasr.com`, the FunASR repository, and the SenseVoice repository all return HTTP 200

GitHub reports the PR mergeable with no configured checks or unresolved review threads. The prior and refreshed heads are retained on `codex/backup-awesome-generative-ai-821-0cab025-20260727` and `codex/backup-awesome-generative-ai-821-pre-push-4a3b2a6-20260727` in the contributor fork.
