### PR TITLE
Add PixelDesk to Productivity — virtual office with AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [NotebookLM](https://notebooklm.google/) - A research and note-taking online tool to interact with documents, powered by Google Gemini.
 - [Open Notebook](https://www.open-notebook.ai) - An open source implementation of NotebookLM with more flexibility and features. [#opensource](https://github.com/lfnovo/open-notebook)
 - [Screenpipe](https://github.com/screenpipe/screenpipe) - An open-source tool for recording screen and audio activity with AI-powered search, automations, and support for local LLMs. #opensource
+- [PixelDesk](https://pixeldesk.ai/) - Pixel-art virtual office where humans and AI agents share desks as characters. Plug any AI (Claude, GPT, Gemini, local Llama / Qwen / DeepSeek via OpenAI-compat, or any MCP server). Agents get persistent memory, task lists, and integrations (Slack, Notion, Telegram, WhatsApp, WeChat, Google Workspace, n8n).
 
 ### Meeting assistants
 


### PR DESCRIPTION
Adding **PixelDesk** to the **Productivity** section (after Screenpipe, before Meeting assistants).

## What it is

[PixelDesk](https://pixeldesk.ai) is a top-down pixel-art virtual office where humans and AI agents share desks as characters. Agents have persistent memory ("brain"), task lists, and integrations with Slack, Notion, Telegram, WhatsApp, WeChat, Google Workspace, n8n.

## Why it fits Productivity

Closest neighbors in the section are Mem, Taskade, Notion AI — all AI-powered workspaces. PixelDesk's distinct angle is spatial presence (each agent has a body, a desk, a schedule) instead of the usual chat-sidebar.

## Connection model

Plug any AI in 30 seconds:
- Claude (API/CLI/subscription), GPT, Gemini, Groq
- Local Llama / Qwen / DeepSeek via OpenAI-compatible endpoints  
- Any MCP server

## Links

- Live: https://pixeldesk.ai (free tier, no credit card)
- Public docs: https://github.com/josueramosleites-collab/pixeldesk-public

Thanks for maintaining this list!