### PR TITLE
add authsome under Coding · Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
 - [Manifest](https://manifest.build) - An open-source LLM router that routes agent requests to the most cost-effective model, with usage limits and model benchmarking. [#opensource](https://github.com/mnfst/manifest)
 - [ai-i18n](https://github.com/i18n-actions/ai-i18n) - A GitHub Action that uses LLMs (Claude, GPT, Ollama) to automatically translate i18n localization files. #opensource
+- [authsome](https://github.com/agentrhq/authsome) - Local credential broker for AI agents. Encrypted vault and loopback HTTPS proxy inject OAuth2 tokens and API keys into outbound provider requests so the agent's process env never holds raw secrets. 45 providers bundled. [#opensource](https://github.com/agentrhq/authsome)
 
 ### Playgrounds
 


### PR DESCRIPTION
hey, opening this to add authsome under Coding → Developer tools.

authsome is a local credential broker for AI agents. log in once via OAuth2 (browser PKCE or device code) or API key, encrypted local vault stores credentials, a loopback HTTPS proxy injects them into outbound provider requests so the agent's process env never holds raw secrets. 45 providers bundled (14 OAuth2, 31 API key) including github, google, openai, linear, slack, notion, resend, stripe.

slots in Developer tools as auth infrastructure for LLM apps — adjacent to rehydra (PII anonymization), Helicone / Langfuse (observability), and Portkey (LLMOps gateway). authsome handles the credential layer those tools don't (rehydra anonymizes prompts, observability tools log calls, authsome makes the underlying API call authenticated and keeps secrets out of the agent process).

if you'd rather have it under Agents → Autonomous agents, happy to move it.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT