### PR TITLE
Add eval-harness to Coding / Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
 - [Manifest](https://manifest.build) - An open-source LLM router that routes agent requests to the most cost-effective model, with usage limits and model benchmarking. [#opensource](https://github.com/mnfst/manifest)
 - [ai-i18n](https://github.com/i18n-actions/ai-i18n) - A GitHub Action that uses LLMs (Claude, GPT, Ollama) to automatically translate i18n localization files. #opensource
+- [eval-harness](https://github.com/nano-step/eval-harness) - Behavior-regression testing for LLM agents with 4-class attribution (skill/fixture/model/unknown), 6-field FAIL schema, flaky detection, and $-cost gating. Ships a GitHub Action + git pre-push hook. [#opensource](https://github.com/nano-step/eval-harness)
 - [Groq](https://groq.com/) - A cloud inference API for running open-source LLMs, powered by custom LPU hardware.
 
 ### Playgrounds


### PR DESCRIPTION
## Adding eval-harness to the Developer tools subsection

**Project**: https://github.com/nano-step/eval-harness
**License**: MIT
**Released**: v0.4.2 on 2026-05-30

## What it does

Behavior-regression testing for LLM agents. Detects when an agent's behavior drifts from a baseline, attributes the cause across 4 deterministic classes (skill / fixture / model / unknown), and emits a 6-field FAIL schema. Ships a composite GitHub Action and a git pre-push hook. Bash + jq, no daemon.

## Why this fits Developer tools

The subsection already includes complementary LLMOps tools (Helicone, Langfuse, Opik, MLflow, OpenLIT). eval-harness sits next to those as the **regression-detection + attribution** slice — a gap the others don't directly fill. Honest comparison: [docs/why-not-promptfoo.md](https://github.com/nano-step/eval-harness/blob/main/docs/why-not-promptfoo.md).

## Project hygiene

- MIT licensed, MIT-only deps
- CONTRIBUTING.md + CODE_OF_CONDUCT.md + SECURITY.md present
- 20/20 test suites green on `main`
- Active maintenance (v0.4.2 shipped 2 days ago; closes 8 audit-surfaced BLOCKERs)

## Transparency on traction

The project is 4 weeks old and currently at a small star count. Opening the PR because the technical, scope, and hygiene bars are met. Happy to revisit at higher traction if preferred.

## Placement

Appended at the end of `### Developer tools` (entries appear to be append-order, not alphabetical).

Thanks for the list.