### PR TITLE
Add DownForAI to Developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -148,6 +148,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
+- [DownForAI](https://downforai.com) - Real-time status monitoring for 800+ AI services like OpenAI, Anthropic, Gemini, and Groq, with uptime checks, latency tracking, and free status badges.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds DownForAI to the Developer tools section of the Discoveries list.

DownForAI is a free real-time status monitoring service for 800+ AI services and tools, including OpenAI, Anthropic, Google Gemini, Groq, Midjourney, and GitHub Copilot. It provides uptime checks, latency tracking, community outage reports, a public status API, and free SVG status badges that developers can embed in their own README files.

The entry has been added to the bottom of the Developer tools section as per the contribution guidelines, with the standard format and a concise description ending with a period.

Happy to adjust the wording or move it to a different section if preferred.