### PR TITLE
Add Hephaestus' Forge to Coding > Developer tools (Discoveries)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -148,6 +148,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
+- [Hephaestus' Forge](https://github.com/r10d1nsec/hephaestus-forge) - Self-hosted tool that interviews you about an idea and forges a build-ready spec (Blueprint, PRD, tech spec, estimation), running on the Claude Code/Codex/Gemini CLI or Ollama you already have. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds Hephaestus' Forge to the Discoveries list under Coding →
  Developer tools (under the 1,000-star threshold for the main list).

  [Hephaestus' Forge](https://github.com/r10d1nsec/hephaestus-forge) is
  a self-hosted, MIT tool that interviews you about an idea and
  generates a build-ready spec (Blueprint, PRD, tech spec, estimation),
  running on the Claude Code/Codex/Gemini CLI or Ollama you already
  have. 100% local.

  Single line appended to the bottom of the category, format and
  #opensource tag match surrounding entries.
