### PR TITLE
Add NextRole to Autonomous agents

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -176,6 +176,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 - [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
+- [NextRole](https://github.com/tam159/next-role) - Open-source GenAI career assistant; a multi-agent system turns your CV and a job description into a tailored resume, interview-prep doc, and day-of battlecard. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds **NextRole** — an open-source (MIT) GenAI career assistant.

A multi-agent system (a supervisor plus hiring-recon, resume-tailor, and interview-coach subagents on LangGraph / DeepAgents) turns a CV + a job description into a tailored resume, an interview-prep doc, and a day-of "battlecard".

- Repo: https://github.com/tam159/next-role
- As a new project, I added it to **`DISCOVERIES.md` → Agents → Autonomous agents** (appended to the category, with the `#opensource` tag and a description ending in a period) per `CONTRIBUTING.md`. Happy to move it to the main list if you would prefer.
