### PR TITLE
Add Atomic Chat to Local LLM Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [PyGPT](https://pygpt.net/) - Personal desktop AI assistant with chat, vision, agents, image generation, tools and commands, voice control and more. #opensource
 - [LLM](https://llm.datasette.io/) - A CLI utility and Python library for interacting with Large Language Models, remote and local. [#opensource](https://github.com/simonw/llm)
 - [LM Studio](https://lmstudio.ai) - Download and run local LLMs on your computer.
+- [Atomic Chat](https://atomic.chat) - GUI-first local AI chat for Mac, Windows, Linux, iOS, and Android, running GGUF and MLX models locally. [#opensource](https://github.com/AtomicBot-ai/Atomic-Chat)
 - [RunThisLLM](https://runthisllm.com) - See which LLMs you can run on your hardware.
 - [Harbor](https://github.com/av/harbor) - A containerized toolkit for running local LLM backends, UIs, and supporting services with one command. #opensource
 - [off-grid-mobile](https://github.com/alichherawalla/off-grid-mobile-ai) - React Native app for running LLMs, vision models, and Stable Diffusion on-device on iOS and Android without internet access. #opensource


### PR DESCRIPTION
Adds [Atomic Chat](https://atomic.chat) to the Local LLM Deployment section, alongside Ollama / Jan / LM Studio.

Open-source, GUI-first local AI app for macOS, Windows, Linux, iOS, and Android. Runs GGUF and MLX models locally with an OpenAI-compatible server and MCP support. Apache-2.0. Single-line addition.