### PR TITLE
Add slopless to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -148,6 +148,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
+- [slopless](https://github.com/seochecks-ai/slopless) - Deterministic textlint preset and CLI that flags AI-generated and padded English prose without calling an LLM. #opensource
 
 ### Playgrounds
 

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -148,7 +148,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
-- [slopless](https://github.com/seochecks-ai/slopless) - Deterministic textlint preset and CLI that flags AI-generated and padded English prose without calling an LLM. #opensource
+- [slopless](https://github.com/seochecks-ai/slopless) - Deterministic textlint preset and CLI to flag AI-generated and padded English prose without calling an LLM. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [slopless](https://github.com/seochecks-ai/slopless) to the Discoveries list under Coding > Developer tools. It is a deterministic textlint preset and CLI that flags AI-generated and padded English prose without calling an LLM, runs in CI, and emits JSON findings. MIT licensed and published on npm as `slopless` (https://www.npmjs.com/package/slopless).