### PR TITLE
Add RunAPI to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Agentset](https://agentset.ai/) - An open-source platform for building and evaluating RAG and agentic applications. [#opensource](https://github.com/agentset-ai/agentset)
 - [Manifest](https://manifest.build) - An open-source LLM router that routes agent requests to the most cost-effective model, with usage limits and model benchmarking. [#opensource](https://github.com/mnfst/manifest)
 - [ai-i18n](https://github.com/i18n-actions/ai-i18n) - A GitHub Action that uses LLMs (Claude, GPT, Ollama) to automatically translate i18n localization files. #opensource
+- [RunAPI](https://runapi.ai/) - A unified API for 130+ generative models across image, video, music, audio, and LLMs from 18 providers, with an [MCP server](https://github.com/runapi-ai/mcp) for Claude Code, Cursor, and Codex.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds **RunAPI** to the Coding → Developer tools section, alongside other unified model-access services (OpenRouter, Together AI, Portkey, Manifest).

RunAPI is a unified API for 130+ generative models across image, video, music, audio, and LLMs from 18 providers. It also ships an MCP server (`npx @runapi.ai/mcp`) for Claude Code, Cursor, and Codex, with free catalog and pricing tools.

- Site: https://runapi.ai/
- MCP server: https://github.com/runapi-ai/mcp

Formatting follows CONTRIBUTING.md: `[ProjectName](Link) - Description.`, added to the bottom of the category, description ends with a period, no trailing whitespace.