### PR TITLE
Add freellmpool to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Manifest](https://manifest.build) - An open-source LLM router that routes agent requests to the most cost-effective model, with usage limits and model benchmarking. [#opensource](https://github.com/mnfst/manifest)
 - [ai-i18n](https://github.com/i18n-actions/ai-i18n) - A GitHub Action that uses LLMs (Claude, GPT, Ollama) to automatically translate i18n localization files. #opensource
 - [Groq](https://groq.com/) - A cloud inference API for running open-source LLMs, powered by custom LPU hardware.
+- [freellmpool](https://0xzr.github.io/freellmpool/) - Pool the free tiers of 16 LLM providers behind one OpenAI-compatible endpoint, with automatic failover. CLI, Python library, local proxy, and MCP server; keyless to start. [#opensource](https://github.com/0xzr/freellmpool)
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [freellmpool](https://github.com/0xzr/freellmpool) to **Developer tools**.

freellmpool is an MIT-licensed, OpenAI-compatible gateway that pools the free tiers of 16 LLM providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere, …) behind one endpoint, with automatic failover. It ships as a CLI, a Python library, a local proxy, and an MCP server, and works with no API key to start (`pip install freellmpool`). It fits alongside the other unified-interface/router tools already listed (OpenRouter, Portkey, Manifest).

Followed the formatting guideline: `[ProjectName](Link) - Description.` with the `#opensource` tag.