### PR TITLE
Add comfy-vault to Discoveries (Image)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -207,6 +207,8 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 ### Stable Diffusion resources
 
+- [comfy-vault](https://github.com/Chepko932/comfy-vault) - Standalone CLI that finds unused models and broken LoRAs in a ComfyUI install.
+
 ## Video
 - [Twelve Labs](https://www.twelvelabs.io/) - Helping developers build programs that can see, listen, and understand the world through video understanding.
 - [invideo AI](https://invideo.io/) - Turn ideas into videos.


### PR DESCRIPTION
Adds **comfy-vault** to the Discoveries list under Image → Stable Diffusion resources.

It's a standalone CLI that finds unused/orphan models and byte-exact duplicate LoRAs in a ComfyUI install (plus Civitai metadata lookup by file hash).

- MIT licensed, on PyPI as `comfy-model-vault`, CI green on Linux + Windows (3.10–3.12), documented.
- Runs without ComfyUI, so it also works on a backup/NAS host.
- Repo: https://github.com/Chepko932/comfy-vault

Format follows CONTRIBUTING (`[Name](link) - Description.`), added to the bottom of the category. Thanks for maintaining the list!