### PR TITLE
Add open-helplines: CC0 community support helpline directory with MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Morpher AI](https://morpher.com/ai) - Morpher AI delivers real-time insights and analysis for any market.
 - [Whimsical AI](https://whimsical.com/ai) - GPT-powered mind mapping, flowcharts, and visual tools for rapid idea development and process organization.
 - [Selfies with Sama](https://selfies-with-sama.vost.ai) - Grab a picture with a real-life billionaire!
+- [open-helplines](https://github.com/Kouki-odaka/open-helplines) - CC0 open data registry of verified community support helplines across 24 countries with a production-ready MCP server. Prevents LLMs from hallucinating emergency contact numbers. Zero API key required. `npx @open-helplines/mcp`.
 
 ## Learning resources
 


### PR DESCRIPTION
## Description

Adds [open-helplines](https://github.com/Kouki-odaka/open-helplines) to the **Other** section.

### About open-helplines

open-helplines is a CC0 open data registry of verified community support helplines across **24 countries**, combined with a production-ready MCP server for generative AI applications.

**The problem it solves:** Generative AI systems often hallucinate when asked for emergency contact numbers. open-helplines provides a verified, structured data source that any LLM or AI agent can query via MCP to surface accurate information.

**Key facts:**
- 24 countries covered
- CC0 public domain data — freely usable in commercial products
- MCP server: `npx @open-helplines/mcp` (zero configuration, no API key)
- Three tools: `find_helplines`, `get_helpline_by_id`, `list_countries`
- JSON Schema–validated records, TypeScript + Python bindings

### Links
- GitHub: https://github.com/Kouki-odaka/open-helplines
- npm: https://www.npmjs.com/package/@open-helplines/mcp
- Site: https://kouki-odaka.github.io/open-helplines/

### License
- Code: Apache-2.0
- Data: CC0-1.0