### PR TITLE
Add Skill Atlas to More lists (Discoveries)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -278,5 +278,6 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Awesome AI Software Development Agents](https://github.com/flatlogic/awesome-ai-software-development-agents) - Curated list of AI agents designed for software development tasks.
 - [MODELDROP](https://modeldrop.fyi/) - A community tracker for new generative media AI model releases.
 - [MyVibe](https://www.myvibe.so) - A feed for discovering and sharing AI-created web apps, demos, and interactive projects.
+- [Skill Atlas](https://github.com/luongs3/skill-atlas) - A trust-rated index of public AI-agent skills organized by job, with source reputation, tier, and freshness on every entry.
 
 ### Lists on ChatGPT


### PR DESCRIPTION
Adds **Skill Atlas** to the Discoveries → More lists section.

It's a curated, trust-rated index of public AI-agent skills organized by job. Unlike a plain link list, every entry carries a trust tier (A canonical → D stale), the reputation signal it's based on (GitHub stars + last-push, pulled live), and a `last_validated` date, with a script + monthly GitHub Action that re-checks sources so entries can't silently rot.

Entry added at the bottom of **More lists**, formatted per CONTRIBUTING (`[Name](Link) - Description.`). Submitting to Discoveries rather than the Main List since it's new and under the 1k-star bar. MIT licensed. No affiliation beyond being the author.