### PR TITLE
Add Latitude to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Manifest](https://manifest.build) - An open-source LLM router that routes agent requests to the most cost-effective model, with usage limits and model benchmarking. [#opensource](https://github.com/mnfst/manifest)
 - [ai-i18n](https://github.com/i18n-actions/ai-i18n) - A GitHub Action that uses LLMs (Claude, GPT, Ollama) to automatically translate i18n localization files. #opensource
 - [Groq](https://groq.com/) - A cloud inference API for running open-source LLMs, powered by custom LPU hardware.
+- [Latitude](https://latitude.so/) - An open-source platform for AI agent observability with semantic trace search and issue tracking. [#opensource](https://github.com/latitude-dev/latitude-llm)
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds Latitude to the Developer tools subsection.

Latitude is an open-source MIT-licensed platform for AI agent observability with semantic trace search and issue tracking. Site: https://latitude.so. Repo: https://github.com/latitude-dev/latitude-llm.