### PR TITLE
Add FerryAPI to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Meta's LLaMA model (and others) in pure C/C++. #opensource
 - [bitnet.cpp](https://github.com/microsoft/BitNet) - Official inference framework for 1-bit LLMs, by Microsoft. [#opensource](https://github.com/microsoft/BitNet)
 - [OpenRouter](https://openrouter.ai/) - A unified interface for LLMs. [#opensource](https://github.com/OpenRouterTeam)
+- [FerryAPI](https://www.ferryapi.io/) - OpenAI-compatible API gateway for routing requests across multiple LLM providers with usage and cost controls.
 - [Ludwig](https://github.com/ludwig-ai/ludwig) - A low-code framework for building custom AI models like LLMs and other deep neural networks. [#opensource](https://github.com/ludwig-ai/ludwig)
 - [Unsloth](https://unsloth.ai) - A Python library for fine-tuning LLMs [#opensource](https://github.com/unslothai/unsloth).
 - [OpenLIT](https://github.com/openlit/openlit) - Open-source GenAI and LLM observability platform native to OpenTelemetry with traces and metrics. #opensource


### PR DESCRIPTION
## Summary

Adds FerryAPI to the Developer tools section as an OpenAI-compatible API gateway for routing requests across multiple LLM providers with usage and cost controls.

## Fit

- The section already includes adjacent LLM infrastructure/services such as OpenRouter, Portkey, Helicone, and Manifest.
- The entry uses the clean homepage URL and a neutral one-line description.

Disclosure: I am affiliated with FerryAPI.