### PR TITLE
Add LLM Flashcards under Learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Generative Artificial Intelligence is a technology that creates original content
 - [Anthropic courses](https://github.com/anthropics/courses) - Anthropic's educational courses.
 - [Build a Large Language Model (From Scratch)](https://www.manning.com/books/build-a-large-language-model-from-scratch) - A guide to building your own working LLM, by Sebastian Raschka.
 - [Prompt Engineering for Vision Models](https://www.deeplearning.ai/short-courses/prompt-engineering-for-vision-models/) - A free DeepLearning.AI short course on how to prompt computer vision models with natural language, bounding boxes, segmentation masks, coordinate points, and other images.
+- [LLM Flashcards](https://github.com/llmsresearch/llm-flashcards) - Hand-drawn flashcards covering the LLM stack from tokenization through RAG to agents. Useful for visual interview prep and quick revision.
 
 ## More lists
 


### PR DESCRIPTION
Adding [LLM Flashcards](https://github.com/llmsresearch/llm-flashcards) under Learning resources.

Hand-drawn flashcards covering core LLM topics: transformer internals, attention, KV cache, RAG, fine-tuning, agents, inference. Useful for visual interview prep and quick revision before ML and AI engineering rounds. The repo has free sample cards; they are part of a 180-card deck I draw at LLMs Research. PDF and Anki formats.

Happy to adjust placement or wording if there is a better fit.