### PR TITLE
Add San to Coding Assistants

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -122,6 +122,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - CLI tool that translates natural-language prompts into shell commands and asks for confirmation before execution.
 - [Yume](https://github.com/aofp/yume) - Desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, and plugin system. #opensource
 - [Frontman](https://frontman.sh/) - A browser-based AI coding agent for editing frontend code with live app context. [#opensource](https://github.com/frontman-ai/frontman)
+- [San](https://genai-io.github.io/san/) - Terminal-native runtime for specialized AI agents; provider-agnostic, runs Claude Code skills, plugins, and MCP servers unmodified, with sandboxed subagents, lifecycle hooks, and a self-evolving memory loop. [#opensource](https://github.com/genai-io/san)
 
 ### Developer tools
 


### PR DESCRIPTION
Adds **San** to the Coding Assistants category.

San is an open-source, terminal-native runtime for specialized AI agents — provider-agnostic, runs Claude Code skills, plugins, and MCP servers unmodified, with sandboxed subagents, lifecycle hooks, and a self-evolving memory loop. Single ~12 MB Go binary, zero runtime dependencies.

- Repo: https://github.com/genai-io/san

Added to the bottom of its category with the `[#opensource]` tag, per CONTRIBUTING.