### PR TITLE
Add routerbase to discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -145,6 +145,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Fiddler.ai](https://www.fiddler.ai) - An AI observability and security platform for monitoring, evaluating, and governing LLM and GenAI applications.
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI for analyzing agentic workflows and surfacing security issues.
 - [AI/ML API](https://aimlapi.com/) - Unified API for accessing multiple AI models across text, image, audio, and video.
+- [routerbase](https://routerbase.com) - OpenAI-compatible AI gateway for 200+ models with smart routing, automatic fallback, unified billing, and usage analytics.
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.


### PR DESCRIPTION
Adds [routerbase](https://routerbase.com) to the Discoveries developer tools section.\n\nRouterBase is an OpenAI-compatible AI gateway for 200+ models with smart routing, automatic fallback, unified billing, and usage analytics.\n\nDocs: https://docs.routerbase.com/