### PR TITLE
Add Agent Token Profiler (Discoveries / Developer tools)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -148,6 +148,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
+- [Agent Token Profiler](https://mnifzied-create.github.io/agentloop/) - See an AI agent's per-turn token cost (system prompt + tool schemas, re-sent every turn) and which tool inflates the context. Free, runs in-browser.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds **Agent Token Profiler** to the Discoveries → Developer tools section.

It's a free, in-browser tool that shows an AI agent's *per-turn* token cost — the system prompt + tool schemas that get re-sent on every request — projects the spend across models, and flags which tool is inflating the context. No signup, no key, runs entirely client-side.

Added to **DISCOVERIES.md** rather than the main list since the project is under the 1,000-follower bar, per the contribution guidelines. Single addition, appended to the bottom of the category, format `[Name](Link) - Description.`

- Tool: https://mnifzied-create.github.io/agentloop/
- Method/data writeup: https://mnifzied-create.github.io/agentloop/token-tax/
