### PR TITLE
Add Prismix to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [ai-i18n](https://github.com/i18n-actions/ai-i18n) - A GitHub Action that uses LLMs (Claude, GPT, Ollama) to automatically translate i18n localization files. #opensource
 - [Groq](https://groq.com/) - A cloud inference API for running open-source LLMs, powered by custom LPU hardware.
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
+- [Prismix](https://prismix.dev) - A dashboard for AI builders: live status monitoring of 75+ AI services (OpenAI, Anthropic, Cursor, etc.) plus a directory of 500+ MCP servers with copy-paste install commands.
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 
 ### Playgrounds


### PR DESCRIPTION
Adds [Prismix](https://prismix.dev) to **Coding → Developer tools**, next to the Model Context Protocol entry.

Prismix is a dashboard for AI builders combining:
- **Live status monitoring** of 75+ AI services (OpenAI, Anthropic, Cursor, Mistral, etc.) with alerts + embeddable badges — sits alongside the observability tools already in this section (Portkey, Langfuse, Helicone)
- **A directory of 500+ MCP servers** with copy-paste install commands & release tracking — complements the existing Model Context Protocol entry

Free to browse, no signup. Live: https://prismix.dev