### PR TITLE
Add AI Pin Maker to Image Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Reve Image](https://reve.com/) - A model trained from the ground up to excel at prompt adherence, aesthetics, and typography.
 - [Magnific](https://www.magnific.com/) - AI-powered design tools including image generation, background removal, and creative templates.
 - [FigureLabs](https://www.figurelabs.ai/) - An AI tool for generating publication-ready scientific figures in vector format from text descriptions or sketches.
+- [AI Pin Maker](https://aipinmaker.com) - All-in-one AI studio for custom enamel pin design, pin art, badges, and creative marketing assets — text-to-image, image-to-image, image-to-video, and text-to-video across 28+ models.
 
 ### Graphic design
 


### PR DESCRIPTION
Adding [AI Pin Maker](https://aipinmaker.com) to the **Image > Services** section.

### What it is
An AI studio that combines text-to-image, image-to-image, image-to-video, and text-to-video generation across 28+ underlying models (DALL·E family, Stable Diffusion, Flux, Wan, Seedream, etc.) in a single interface — with a niche focus on **custom enamel pin / pin art / badge design** workflows.

### Why this is a niche/unique fit (per Inclusion Criteria #2)
- No other entry in this list targets **enamel pin / pin art / merchandising design** specifically. General-purpose tools (DALL·E, Midjourney, Leonardo) cover broad image generation but lack the pin-specific composition presets, mockup generators, and packaging-ready output formats this tool ships.
- Multi-locale (en/zh/ja/ko/pt-BR/ar) landing pages for international maker / indie brand communities.
- Free tier — no signup required to preview the studio.

### Format check
- [x] Single line added to `README.md` under `## Image > ### Services`
- [x] Uses `- [Name](url) - Description.` per CONTRIBUTING.md
- [x] Description ends with a period
- [x] Added to the bottom of the Services category
- [x] No duplicates (grepped for "Pin Maker", "aipinmaker")