### PR TITLE
Add Drawtoon to Discoveries (Image > Services)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -198,6 +198,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [deAPI.ai](https://deapi.ai/) - A unified inference API to open-source AI models for text-to-image, text-to-speech, transcription, video generation, and more, using a decentralized GPU cloud.
 - [MyPicNow](https://www.mypicnow.com) - An AI headshot generator for creating professional profile photos from uploaded selfies.
 - [PhotoMentor](https://photomentor.pro) - An AI tool for analyzing photos and providing composition and lighting feedback.
+- [Drawtoon](https://drawtoon.app) - AI comic studio that turns a story prompt into full manga and manhwa pages with consistent characters, panels, and dialogue.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds **Drawtoon** to the Discoveries list under Image > Services, following CONTRIBUTING.md (added to the bottom of the category, format `[Name](Link) - Description.`).

Drawtoon is an AI comic studio that turns a story prompt into full manga and manhwa pages with consistent characters, panels, and dialogue, then publishes to a community feed.

- Website: https://drawtoon.app

Placed in Discoveries rather than the main list as it's a newer project. Thanks!