### PR TITLE
Add ccline - natural language zsh prompt with AI answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [v0](https://v0.dev) - Prompt-driven UI generation for React and Next.js, creating production-ready components.
 - [Lovable](https://lovable.dev) - Conversational full-stack app generation, turning ideas into deployable code.
 - [aider](https://aider.chat/) - AI pair programming in your terminal, supporting multiple LLM providers. [#opensource](https://github.com/paul-gauthier/aider)
+- [ccline](https://github.com/jianshuo/ccline) - Type a natural-language thought directly at your zsh prompt and get an AI answer; run suggested commands with one keypress in your live shell. Hijacks `command_not_found_handler`. [#opensource](https://github.com/jianshuo/ccline)
 - [Kilo](https://kilo.ai/) - Open-source AI coding assistant for VS Code, JetBrains, and the CLI. [#opensource](https://github.com/Kilo-Org/kilocode)
 
 ### Developer tools


### PR DESCRIPTION
## What is ccline?

**ccline** brings AI to where you already are — your terminal prompt.

Type a natural-language thought directly at your zsh prompt (no command, no prefix). ccline hijacks `command_not_found_handler`:
- One word → treated as a normal typo (`zsh: command not found: gti`)
- Two or more words → sent to Claude/Codex, answer rendered as Markdown

If the answer contains shell commands, an arrow-key menu lets you confirm and run them in your **live shell** — `cd`, `export`, history all persist.

```
$ how do I find files bigger than 100MB here

    find . -maxdepth 1 -type f -size +100M

Commands found — ↑/↓ to choose, Enter to run, q to cancel:
 ❯ find . -maxdepth 1 -type f -size +100M
   find . -type f -size +100M
```

Uses Claude (preferred) or Codex as AI backend. No extra dependencies needed.

**Install:** `curl -fsSL https://raw.githubusercontent.com/jianshuo/ccline/v0.2.2/install.sh | bash`

GitHub: https://github.com/jianshuo/ccline