### PR TITLE
Add Cate to Coding Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Lovable](https://lovable.dev) - Conversational full-stack app generation, turning ideas into deployable code.
 - [aider](https://aider.chat/) - AI pair programming in your terminal, supporting multiple LLM providers. [#opensource](https://github.com/paul-gauthier/aider)
 - [Kilo](https://kilo.ai/) - Open-source AI coding assistant for VS Code, JetBrains, and the CLI. [#opensource](https://github.com/Kilo-Org/kilocode)
+- [Cate](https://cate.cero-ai.com) - An open source IDE on an infinite zoomable canvas, where editors, terminals, browsers, and Claude Code agent panels float in spatial workspaces instead of tabs. [#opensource](https://github.com/0-AI-UG/cate)
 
 ### Developer tools
 


### PR DESCRIPTION
Adds Cate to the Coding Assistants section. Cate is an open source desktop IDE (MIT, ~1.3k stars, actively developed) built on an infinite canvas. It includes built-in AI agent panels (Claude Code) alongside Monaco editors, terminals, and embedded browsers. Cross-platform: macOS, Windows, Linux.
