### PR TITLE
Add auto-geo

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -258,6 +258,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GPU Per Hour](https://gpuperhour.com) - Real-time GPU cloud price comparison across multiple providers.
 - [DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) - A personal genome analysis toolkit powered by Claude Code that analyzes raw DNA data across 17 categories and generates terminal-style visualizations. #opensource
 - [Enconvo](https://enconvo.com) - A macOS AI launcher with a system-wide bar, voice input, multi-LLM support, and a plugin ecosystem.
+- [auto-geo](https://github.com/shadowresearch/auto-geo) - Open-source CLI that audits pages for AI-citation readiness and measures whether ChatGPT, Claude, Gemini, Perplexity, and Grok cite a domain. #opensource
 
 ## Learning resources
 


### PR DESCRIPTION
This PR adds [auto-geo](https://github.com/shadowresearch/auto-geo) to the Discoveries list (Other section): an open-source CLI that audits pages for AI-citation readiness and measures whether ChatGPT, Claude, Gemini, Perplexity, and Grok cite a domain.

It is a new project, so per the contribution guidelines it is submitted to DISCOVERIES.md rather than the main list. It is MIT-licensed and open source: https://github.com/shadowresearch/auto-geo

Disclosure: I work on auto-geo at Shadow.