### PR TITLE
Add Aiprosol to Discoveries (Other)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -258,6 +258,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GPU Per Hour](https://gpuperhour.com) - Real-time GPU cloud price comparison across multiple providers.
 - [DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) - A personal genome analysis toolkit powered by Claude Code that analyzes raw DNA data across 17 categories and generates terminal-style visualizations. #opensource
 - [Enconvo](https://enconvo.com) - A macOS AI launcher with a system-wide bar, voice input, multi-LLM support, and a plugin ecosystem.
+- [Aiprosol](https://aiprosol.com/) - An AI automation consultancy operated by an AI C-suite of ten agents, with its live operational state published at aiprosol.com/agents.
 
 ## Learning resources
 


### PR DESCRIPTION
Adds [Aiprosol](https://aiprosol.com) to the **Discoveries list** (Other section) — deliberately not the Main List, since the project doesn't yet meet the 1,000-follower criterion.

Aiprosol is an AI automation consultancy operated end-to-end by an AI C-suite: Arora, an AI CEO, coordinating nine specialist agents (ops, marketing, revenue, legal, product, data…), chaired by the founder. What makes it relevant to this list: the agents' live operational state — every run, decision, and KPI — is public at https://aiprosol.com/agents and https://aiprosol.com/transparency, as a working test of whether an AI-led operating model can run a real company.

Format follows CONTRIBUTING.md: single entry, bottom of its category, concise description ending with a period, no tracking parameters.