### PR TITLE
Add Headroom — Claude Code rate-limit monitor for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [Headroom](https://headroom.walls.sh) - A macOS menu bar app that shows Claude Code's session (5h) and weekly (7d) rate-limit usage as a live percentage with color-coded alerts and reset countdowns. Zero network calls. [#opensource](https://github.com/patwalls/headroom)
 
 ### Playgrounds
 


### PR DESCRIPTION
## What

Adds [Headroom](https://headroom.walls.sh) to the **Developer tools** section.

## Why it fits

Headroom is a macOS menu bar app for developers using Claude Code (Anthropic's agentic coding tool, already listed under Autonomous agents). It surfaces Claude Code's session (5h) and weekly (7d) rate-limit usage as a live %, color-coded before a limit stops you mid-task — the same data `/usage` shows, from a local file Claude Code already writes.

Key differentiators relevant to this list's audience:
- **Zero network calls** — no API key, no token, no analytics; reads a local file written by Claude Code's own status line hook
- **~267 KB**, signed & notarized, macOS 13+, MIT
- Directly complements the Claude Code workflow already represented in this list

## Entry added

```markdown
- [Headroom](https://headroom.walls.sh) - A macOS menu bar app that shows Claude Code's session (5h) and weekly (7d) rate-limit usage as a live percentage with color-coded alerts and reset countdowns. Zero network calls. [#opensource](https://github.com/patwalls/headroom)
```

Placed at the end of the Developer tools section, after Bifrost.