### PR TITLE
Add Hivekeep to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -175,6 +175,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 - [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
+- [Hivekeep](https://hivekeep.app) - A self-hosted platform of autonomous, persistent personal AI agents that collaborate, remember, and build their own tools, reachable via Telegram, WhatsApp, Slack, Discord, Signal and Matrix. [#opensource](https://github.com/MarlBurroW/hivekeep)
 
 ### Custom assistants
 


### PR DESCRIPTION
Adding Hivekeep to DISCOVERIES.md under Agents, Autonomous agents, at the bottom of the category as per the contribution guidelines.

Hivekeep is a self-hosted, MIT-licensed platform of autonomous, persistent personal AI agents: a team of specialized agents with continuous memory that collaborate, build their own tools, and are reachable over Telegram, WhatsApp, Slack, Discord, Signal and Matrix. Single container with Bun and SQLite.

Disclosure: I am the author of the project. Thanks!