### PR TITLE
Add Superhighway to Search engines section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Phind](https://phind.com/) - AI-based search engine.
 - [You.com](https://you.com/) - A search engine built on AI that provides users with a customized search experience while keeping their data 100% private.
 - [Komo](https://komo.ai/) - An AI-powered search engine.
+- [Superhighway](https://superhighway.walls.sh) - Web search API for AI agents — five tools (search, news, images, scrape, research), pay per call in USDC on Base via x402 or free API key.
 
 ### Local search engines
 


### PR DESCRIPTION
Adds [Superhighway](https://superhighway.walls.sh) to the **Search engines** section.

**What it is:** A web search API built specifically for AI agents — five tools (search, news, images, scrape, research) that agents can pay for per call in USDC on Base via x402, or use with a free API key (1,000 calls/month). No signup required for x402 path.

It fits alongside Perplexity, Exa, and Phind as a search tool in the AI/LLM ecosystem, with the distinction that it's designed for autonomous agents rather than end users.