### PR TITLE
Add AIToolIndex to discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -284,5 +284,6 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Awesome AI Software Development Agents](https://github.com/flatlogic/awesome-ai-software-development-agents) - Curated list of AI agents designed for software development tasks.
 - [MODELDROP](https://modeldrop.fyi/) - A community tracker for new generative media AI model releases.
 - [MyVibe](https://www.myvibe.so) - A feed for discovering and sharing AI-created web apps, demos, and interactive projects.
+- [AIToolIndex](https://aitoolindex.io/) - A searchable AI tool directory for comparing tools by category, use case, pricing model, alternatives, and workflow fit.
 
 ### Lists on ChatGPT


### PR DESCRIPTION
## Summary
- Add AIToolIndex to the Discoveries list under More lists.

## Notes
I used DISCOVERIES.md rather than the main README because the contribution guide says smaller or emerging projects should be added there.