### PR TITLE
feat(developer-tools): add Prismix AI service status monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome Generative AI [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)
+﻿# Awesome Generative AI [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)
 
 > A curated list of modern Generative Artificial Intelligence projects and services.
 
@@ -241,6 +241,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
 
+- [Prismix](https://prismix.dev) - Real-time status dashboard for 75+ AI services (OpenAI, Anthropic, Cursor, Groq, DeepSeek, Gemini, etc.) with free email alerts, MCP server for Claude Desktop, curated AI news feed, and MCP server directory. [#opensource](https://github.com/Prismor/Pulse)
 ### Playgrounds
 
 - [OpenAI Playground](https://platform.openai.com/playground) - Explore resources, tutorials, API docs, and dynamic examples.


### PR DESCRIPTION
Adds Prismix to the Coding/Developer tools section alongside Portkey, OpenLIT, Helicone, Langfuse, and Opik.

Prismix monitors real-time status of 75+ AI services (OpenAI, Anthropic, Cursor, Groq, DeepSeek, Gemini, etc.) — unlike LLMOps tracing tools, Prismix tracks the upstream AI services themselves. Free email alerts, MCP server for Claude Desktop, AI news feed, MCP directory.

Live: https://prismix.dev