### PR TITLE
Add CreatorSkills to Writing assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [QuillBot](https://quillbot.com) - AI-powered paraphrasing tool.
 - [Postwise](https://postwise.ai/) - Write tweets, schedule posts and grow your following using AI.
 - [Copysmith](https://copysmith.ai/) - AI content creation solution for Enterprise & eCommerce.
+- [CreatorSkills](https://creatorskills.co) - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
 
 ### ChatGPT extensions
 


### PR DESCRIPTION
## Summary

Adds [CreatorSkills](https://creatorskills.co) to the **Writing assistants** section.

CreatorSkills is a marketplace of 30+ downloadable AI skill packs specifically designed for content creators, covering YouTube scripting, sponsorship analysis, audience growth, and more. Skills are compatible with Claude and ChatGPT.

## Why it fits

- Helps content creators write better (YouTube scripts, email outreach, content briefs)
- External hosted web tool using generative AI
- Works with the leading generative AI models (Claude, ChatGPT)