### PR TITLE
Add DOS Kernel to Developer tools (Discoveries)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -149,6 +149,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
+- [DOS Kernel](https://github.com/anthony-chaudhary/dos-kernel) - A deterministic trust kernel that verifies AI coding agents' "done" claims against git evidence instead of self-report. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds DOS Kernel — https://github.com/anthony-chaudhary/dos-kernel — to **Coding › Developer tools** in DISCOVERIES.md (added at the bottom of the category per CONTRIBUTING).

DOS is a deterministic trust kernel for AI coding agents and agent fleets. It computes verdicts from evidence the agent didn't author: `dos verify` checks that a claimed unit of work actually landed (git ancestry, not self-report), `dos arbitrate` decides whether two concurrent agents may touch the same files, and `dos commit-audit` flags a commit whose message claims work its own diff doesn't contain. MIT-licensed, Python (PyPI: `dos-kernel`), ships an MCP server (`dos-mcp`) and hooks for Claude Code, Cursor, Codex, Gemini CLI, Antigravity, and Claude Cowork.

Placement follows the list's contribution guidelines; link verified.