### PR TITLE
Add TopoAI to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -260,6 +260,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) - A personal genome analysis toolkit powered by Claude Code that analyzes raw DNA data across 17 categories and generates terminal-style visualizations. #opensource
 - [Enconvo](https://enconvo.com) - A macOS AI launcher with a system-wide bar, voice input, multi-LLM support, and a plugin ecosystem.
 - [KeepRule](https://keeprule.com) - Investment-discipline tool with curated principles from 26 investors and AI prompts for scenario analysis.
+- [TopoAI](https://www.topoai.cc/) - AI-assisted topology and network diagram generator for creating editable first drafts from sanitized architecture prompts.
 
 ## Learning resources
 


### PR DESCRIPTION
Adds TopoAI as an AI-assisted topology and network diagram generator in the Discoveries list.