### PR TITLE
Add OpenAcme to Autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [OpenAcme](https://github.com/sandydasari/openacme) - Local-first AI workforce platform where named agents with roles, tools, memory, and per-agent MCP servers self-organize through task delegation. Supports Anthropic, OpenAI, Google, OpenRouter, and Ollama. [#opensource](https://github.com/sandydasari/openacme)
 
 ### Custom assistants
 


### PR DESCRIPTION
## What

Adds [OpenAcme](https://github.com/sandydasari/openacme) to the **Autonomous agents** section.

## Why

OpenAcme is a local-first AI workforce platform where named agents with roles, tools, memory, and per-agent MCP servers self-organize through task delegation. It fits the Autonomous agents category: agents run independently, assign work to each other via a shared task board, and the scheduler wakes coworkers when dependencies clear.

- **License:** MIT (open source)
- **Language:** TypeScript
- **Providers:** Anthropic, OpenAI, Google, OpenRouter, Ollama
- **Install:** `npm install -g @openacme/cli`