### PR TITLE
Add LLM Abacus to Leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenRouter LLM Rankings](https://openrouter.ai/rankings) - Language models ranked and analyzed by usage across apps.
 - [SEAL LLM Leaderboard](https://labs.scale.com/leaderboard) - Expert-driven LLM benchmarks and updated AI model leaderboards.
 - [LLM Stats](https://llm-stats.com/) - Compare AI models across benchmarks, pricing, speed, and context window.
+- [LLM Abacus](https://llmabacus.com/en) - Compare LLM API prices across 42 models and 14 providers, with a token and cost estimator and source-linked, daily-verified figures.
 
 ### Other text generators
 


### PR DESCRIPTION
Adds LLM Abacus (https://llmabacus.com/en) to the Text > Leaderboards section.

It compares LLM API prices across 42 models and 14 providers in one sortable table, includes a paste-text token and cost estimator, covers embedding/media model pricing, and links every price to the vendor's official docs with daily verification. This sits alongside existing entries like LLM Stats and Artificial Analysis that compare models on pricing.

The entry follows the CONTRIBUTING format (`[Name](URL) - Description.`) and is added at the bottom of the category. The linked page is the English version of the tool.

Disclosure: I maintain LLM Abacus and am submitting it as a useful pricing-comparison resource for this section.