### PR TITLE
Add NarraNexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [NarraNexus](https://github.com/NetMindAI-Open/NarraNexus) - A ready-to-run AI agent team workspace whose agents remember, collaborate, and use tools from day one. Multi-agent collaboration, persistent memory across sessions, and MCP-style tool integrations. [#opensource](https://github.com/NetMindAI-Open/NarraNexus)
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds **NarraNexus** (https://github.com/NetMindAI-Open/NarraNexus) to the Autonomous agents section.

NarraNexus is an open-source, ready-to-run AI agent team workspace by NetMind.AI — agents that remember, collaborate, and use tools from day one. Features persistent memory across sessions, multi-agent collaboration (PM, developer, deployment, research), and MCP-style tool integrations.