### PR TITLE
Add Hailuo 2 Video to Discoveries — Video

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -223,6 +223,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [Hailuo 2 Video](https://hailuo2.video/) - Browser-based image-to-video web app built around the Hailuo model. Takes a first-frame image and prompt, returns a short cinematic clip. Free trial available.
 
 ### Avatars
 


### PR DESCRIPTION
Adding hailuo2.video to the Generative AI Discoveries list, in the Video section.

Hailuo 2 Video is an independent third-party web app (not affiliated with Hailuo AI or MiniMax) that turns a first-frame image plus a short prompt into a short cinematic video clip using the Hailuo model. It offers a one-video-per-2-day free trial for visitors in EU/UK/NA/ANZ/JP, with no signup required for the trial.

I'm placing this in the **Discoveries** list rather than the main README because:
- The main list already has Hailuo AI (the official product at hailuoai.video).
- This is a different, independent product built around the same model — a third-party web app, not the official one.
- Discoveries is the right home for newer / less-known tools that don't yet meet the 1k-followers bar for the main list.

Followed the contribution format: `- [Name](URL) - Description.`. Description is concise, neutral, and ends with a period.