### PR TITLE
Add PodCrisp to DISCOVERIES (Audio > Speech-to-text)

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [FinChat](https://finchat.io/) - Using AI, FinChat generates answers to questions about public companies and investors.
 - [Morpher AI](https://morpher.com/ai) - Morpher AI delivers real-time insights and analysis for any market.
 - [Whimsical AI](https://whimsical.com/ai) - GPT-powered mind mapping, flowcharts, and visual tools for rapid idea development and process organization.
+- [PodCrisp](https://podcrisp.com/) - AI-powered podcast naming and SEO optimization tool. Generate the perfect podcast name and optimize discoverability.
 - [Selfies with Sama](https://selfies-with-sama.vost.ai) - Grab a picture with a real-life billionaire!
 
 ## Learning resources


### PR DESCRIPTION
Adds [PodCrisp](https://podcrisp.com) to **DISCOVERIES.md → Audio → Speech-to-text**.

**Description:** PodCrisp is an AI podcast tool for indie podcasters. Upload an episode (or RSS) and get back transcripts, AI show notes, chapters, episode summaries, and tweet-ready drafts in minutes. Built around Whisper + GPT.

**Why it fits this list:** Same category as the existing Speech-to-text entry (Typist) in the Discoveries list. Format follows the CONTRIBUTING.md template: `[ProjectName](Link) - Description.` ending with a period and appended to the bottom of the relevant subsection.

**Discoveries vs Main list:** PodCrisp is a small, recently launched indie project that does not meet the 1000+ followers bar for the main list, so it is being submitted to DISCOVERIES.md per the contribution guidelines.

Homepage: https://podcrisp.com