### PR TITLE
Add Modelis (auto-routing LLM API gateway) to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [LLM App](https://github.com/pathwaycom/llm-app) - Open-source Python library to build real-time LLM-enabled data pipeline.
 - [LMQL](https://lmql.ai/) - LMQL is a query language for large language models.
 - [LlamaIndex](https://www.llamaindex.ai/) - A data framework for building LLM applications over external data.
+- [Modelis](https://modelishub.com/) - OpenAI-compatible LLM API gateway that auto-routes each request to the right model (GPT, Claude, Gemini) at a flat, predictable per-call price.
 - [Phoenix](https://phoenix.arize.com/) - Open-source tool for ML observability that runs in your notebook environment, by Arize. Monitor and fine tune LLM, CV and tabular models.
 - [Cursor](https://cursor.com/) - Cursor is the IDE of the future, built for pair-programming with Powerful AI.
 - [SymbolicAI](https://github.com/ExtensityAI/symbolicai) - A neuro-symbolic framework for building applications with LLMs at the core.


### PR DESCRIPTION
Adds **Modelis** to the Developer tools section - an OpenAI-compatible LLM API gateway that auto-routes each request to the right model (GPT/Claude/Gemini) and bills a flat, predictable per-call price. Same category as OpenRouter, Portkey and Together AI already listed; kept in alphabetical order. Thanks for maintaining this list!