### PR TITLE
Add AI Price Index to Developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -149,6 +149,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
+- [AI Price Index](https://github.com/RoninForge/ai-price-index) - An open, dated dataset of LLM API prices over time, with a verifiable first-party source on every price. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [AI Price Index](https://github.com/RoninForge/ai-price-index) to the Developer tools category of the Discoveries list (the project is under the 1,000-follower bar for the main list).

It is an open, dated dataset of LLM API prices over time. Every price links a verifiable first-party source and carries the date it was valid, so historical usage can be priced point-in-time instead of extrapolating from today.

- Open source tooling (MIT) and open data (CC BY 4.0), with a Zenodo DOI
- Actively maintained: a bot diffs the official pricing pages daily and flags drift, and every price change is human-reviewed before merge
- 10 providers, 86 models

Entry added to the bottom of the category per CONTRIBUTING.