### PR TITLE
docs: add Suede AI discovery

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -244,6 +244,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Boomy](https://boomy.com/) - Create original songs in seconds.
 - [Soundraw](https://soundraw.io/) - Create your beats with the power of AI.
 - [Jammable](https://www.jammable.com/) - AI voice covers and music creation platform.
+- [Suede AI](https://suedeai.ai/) - Rights-aware music and video generation platform with provenance, programmable-IP workflows, and agent-facing x402 resources for generation, rights lookup, and audio analysis.
 
 ## Other
 


### PR DESCRIPTION
Adds Suede AI to the Discoveries list under Audio > Music, matching the contribution guidance for projects that may not yet meet the main-list threshold.

Live verification before opening this PR:
- https://suedeai.ai returned 200
- https://app.suedeai.ai/.well-known/agent-card.json returned `Suede AI Agent`
- https://app.suedeai.ai/openapi.json reported 22 paths
- https://app.suedeai.ai/.well-known/x402.json exposes 22 x402 resources

Validation:
- git diff --check