### PR TITLE
add presentation design prompts

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -286,5 +286,6 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Awesome AI Software Development Agents](https://github.com/flatlogic/awesome-ai-software-development-agents) - Curated list of AI agents designed for software development tasks.
 - [MODELDROP](https://modeldrop.fyi/) - A community tracker for new generative media AI model releases.
 - [MyVibe](https://www.myvibe.so) - A feed for discovering and sharing AI-created web apps, demos, and interactive projects.
+- [Presentation Design Prompts](https://github.com/SlideSpeak/presentation-design-prompts) - 56 free slide-design prompts for ChatGPT and Claude, each pinning a color palette, fonts, and layout rules for a full deck theme.
 
 ### Lists on ChatGPT


### PR DESCRIPTION
Adding an entry to the Discoveries list (the repo is well under the 1k-star bar for the main list, so this felt like the right home).

I maintain an open-source collection of slide-design prompts for ChatGPT and Claude. Each entry is one prompt that carries a full design system: a color palette pinned to hex values, named Google Fonts, and layout rules. The model then produces a consistent deck instead of clip-art slides. 56 themes, MIT licensed.

Repo: https://github.com/SlideSpeak/presentation-design-prompts

I put it under More lists since it reads as a curated collection, but Other works too. Move or reword it however you like. Thanks!
