### PR TITLE
Add ByteCosts to Leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenRouter LLM Rankings](https://openrouter.ai/rankings) - Language models ranked and analyzed by usage across apps.
 - [SEAL LLM Leaderboard](https://labs.scale.com/leaderboard) - Expert-driven LLM benchmarks and updated AI model leaderboards.
 - [LLM Stats](https://llm-stats.com/) - Compare AI models across benchmarks, pricing, speed, and context window.
+- [ByteCosts](https://bytecosts.com/) - Source-linked pricing for thousands of AI models across 145 providers, with cost calculators and recorded price changes.
 
 ### Other text generators
 


### PR DESCRIPTION
Adds [ByteCosts](https://bytecosts.com/) under **Text → Leaderboards**, alongside the existing model-comparison entries (LLM Stats, Artificial Analysis).

ByteCosts is a source-linked pricing comparison for thousands of AI models across 145 providers: every price links to the provider's own page with a last-checked date, plus monthly cost calculators and recorded price changes over time. Fully static, no signup.

Open dataset (CC-BY-4.0, citable): https://github.com/erson/ai-pricing-index

Formatting per CONTRIBUTING: `[Name](Link) - Description.`, added to the bottom of the category, single line, trailing period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)