### PR TITLE
Add Satcove to Custom interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 
 - [LibreChat](https://librechat.ai/) - LibreChat is a free and open-source chat interface for assistant AIs. [#opensource](https://github.com/danny-avila/LibreChat).
 - [Chatbot UI](https://www.chatbotui.com/) - An open source ChatGPT UI. [#opensource](https://github.com/mckaywrigley/chatbot-ui).
+- [Satcove](https://satcove.com/) - Queries six AI models (Claude, GPT, Gemini, Mistral, Perplexity, Grok) in parallel and synthesizes one answer with an agreement score.
 
 ### Search engines
 


### PR DESCRIPTION
Adds Satcove under Text › Custom interfaces.

Satcove is a multi-AI consensus interface: it queries six models (Claude, GPT, Gemini, Mistral, Perplexity, Grok) in parallel and synthesizes a single answer with an agreement score, surfacing where the models agree and disagree. It fits alongside the other multi-model interfaces in this section.

- Entry follows the `- [Name](url) - Description.` format
- One line, factual, no promotional language