### PR TITLE
Add AiToolsObserver to Discoveries services

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -199,6 +199,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [deAPI.ai](https://deapi.ai/) - A unified inference API to open-source AI models for text-to-image, text-to-speech, transcription, video generation, and more, using a decentralized GPU cloud.
 - [MyPicNow](https://www.mypicnow.com) - An AI headshot generator for creating professional profile photos from uploaded selfies.
 - [PhotoMentor](https://photomentor.pro) - An AI tool for analyzing photos and providing composition and lighting feedback.
+- [AiToolsObserver](https://aitoolsobserver.com/) - AI discovery platform for comparing and tracking AI tools through curated insights, trends, and practical use cases.
 
 ### Graphic design
 


### PR DESCRIPTION
## What changed

Adds AiToolsObserver to the **Services** category in `DISCOVERIES.md`.

AiToolsObserver is an AI discovery platform for comparing and tracking AI tools through curated insights, trend coverage, and practical use cases. It also accepts free AI tool submissions.

## Why Discoveries

I targeted the inclusive Discoveries list rather than the stricter main list, following the contribution criteria for useful generative-AI services that may not meet the main list's follower threshold.

## Disclosure and validation

- I am affiliated with AiToolsObserver
- Confirmed the website is live
- Checked that the URL is not already listed
- Added the entry at the bottom of its category