### PR TITLE
Add AI Prompt Architect

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,3 +475,5 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [FlowGPT](https://flowgpt.com/) - Amplify your workflow with the best prompts.
 - [ChatGPT Prompts for Data Science](https://github.com/travistangvh/ChatGPT-Data-Science-Prompts) - A repository of useful data science prompts for ChatGPT.
 - [Awesome ChatGPT](https://github.com/sindresorhus/awesome-chatgpt) - Another awesome list for ChatGPT.
+
+- [AI Prompt Architect](https://aipromptarchitect.co.uk) - Enterprise prompt engineering IDE with version control, automated evals, and multi-model testing.


### PR DESCRIPTION
Adding AI Prompt Architect (https://aipromptarchitect.co.uk) — an enterprise-grade prompt engineering IDE for designing, versioning, testing, and optimizing prompts across multiple LLMs.