### PR TITLE
Add SkillDepot - AI Agent skills marketplace for cross-border ecommerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 
 ### Developer tools
 
+- [SkillDepot](https://skills.rehomi.com) - Open marketplace for AI Agent skills focused on cross-border ecommerce (Alibaba International, Amazon, Shopify).Skills are packaged as ZIP files with SKILL.md metadata, rated by community with anti-gaming leaderboard. Open source.
 - [Cohere](https://cohere.com/) - Cohere provides access to advanced Large Language Models and NLP tools.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.
 - [LangChain](https://langchain.com/) - A framework for developing applications powered by language models.


### PR DESCRIPTION
## Description
   Add [SkillDepot](https://skills.rehomi.com) - an open marketplace for AI Agent skills.
   
   SkillDepot focuses on cross-border ecommerce automation (Alibaba International, Amazon, Shopify).
   Skills are downloaded as ZIP packages and can be imported into any AI workbench.
   
   - URL: https://skills.rehomi.com
   - GitHub: https://github.com/jack12w/agent-skill-platform
   - License: MIT
   - Free to use
   
   ## Checklist
   - [x] The entry is placed in the correct alphabetical order
   - [x] Format follows: `-[Name](URL)- Description`