### PR TITLE
Add Auferet to the Other list

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Morpher AI](https://morpher.com/ai) - Morpher AI delivers real-time insights and analysis for any market.
 - [Whimsical AI](https://whimsical.com/ai) - GPT-powered mind mapping, flowcharts, and visual tools for rapid idea development and process organization.
 - [Selfies with Sama](https://selfies-with-sama.vost.ai) - Grab a picture with a real-life billionaire!
+- [Auferet](https://auferet.com/) - A text adventure and solo RPG you direct, with an AI game master that remembers your story and your uploaded lore.
 
 ## Learning resources
 


### PR DESCRIPTION
Adds **Auferet** to the **Other** section, right alongside AI Dungeon, which it is a direct peer to.

Auferet is an AI game master for solo text adventures and tabletop-style RPGs. Its distinguishing capability is persistence: it keeps a long-term memory of your story and lets you upload your own lore documents (retrieval-augmented), so the world stays consistent across long play sessions. It runs as a web app and a published Android app, and is actively maintained.

This fits inclusion criterion 2 (a niche application showcasing a unique capability in generative AI). Happy to move it to the Discoveries list instead if you prefer. The link resolves (HTTP 200) and the entry follows the `[Name](Link) - Description.` format, added to the bottom of its category.