### PR TITLE
Add Sparkiz.ai to Video / Avatars

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [D-ID](https://www.d-id.com/) - Create and interact with talking avatars at the touch of a button.
 - [HeyGen](https://app.heygen.com/) - Turn scripts into talking videos with customizable AI avatars in minutes.
 - [Affogato](https://affogato.ai/) - Create AI-generated product video ads for TikTok, Reels, and Shorts.
+- [Sparkiz.ai](https://sparkiz.ai) - Turn a product link into an AI video ad with avatars, voiceover, and captions in 60 seconds.
 
 ### Animation
 


### PR DESCRIPTION
Adding **Sparkiz.ai** to the Video → Avatars subsection, next to similar product-video-ad tools (Affogato, HeyGen).

Sparkiz.ai turns a product link into a ready-to-launch AI video ad — a realistic avatar holding the real product, auto-written script, voiceover, synced captions and music — in under 60 seconds. Built for ecommerce.

Website: https://sparkiz.ai
Format follows the existing `- [Name](URL) - Description.` convention.