### PR TITLE
Add SayCraft to Coding Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Lovable](https://lovable.dev) - Conversational full-stack app generation, turning ideas into deployable code.
 - [aider](https://aider.chat/) - AI pair programming in your terminal, supporting multiple LLM providers. [#opensource](https://github.com/paul-gauthier/aider)
 - [Kilo](https://kilo.ai/) - Open-source AI coding assistant for VS Code, JetBrains, and the CLI. [#opensource](https://github.com/Kilo-Org/kilocode)
+- [SayCraft](https://saycraft.ai) - Conversational app builder for teams: talk through what you want in a meeting and the AI builds a working web app live with a shareable preview.
 
 ### Developer tools
 


### PR DESCRIPTION
Adds **SayCraft** to Coding Assistants.

SayCraft is a conversational, multiplayer app builder: instead of one person typing prompts, a team opens a meeting and talks through what to build, and the AI generates a working web app live with a shareable preview URL. Fits alongside v0 and Lovable in this section.

- Site: https://saycraft.ai
- Entry uses the `[ProjectName](Link) - Description.` format.