### PR TITLE
Add Pedra to Image > Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Reve Image](https://reve.com/) - A model trained from the ground up to excel at prompt adherence, aesthetics, and typography.
 - [Magnific](https://www.magnific.com/) - AI-powered design tools including image generation, background removal, and creative templates.
 - [FigureLabs](https://www.figurelabs.ai/) - An AI tool for generating publication-ready scientific figures in vector format from text descriptions or sketches.
+- [Pedra](https://pedra.ai/) - AI photo and video editing for real-estate listings: virtual staging, renovation, room emptying, photo enhancement, sky replacement, and object removal.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds [Pedra](https://pedra.ai/) to **Image › Services**, alongside PhotoRoom/ClipDrop/Magnific.

Pedra is an AI photo and video editing platform for real-estate listings — virtual staging, renovation, room emptying, photo enhancement, sky replacement, and object removal. It's a funded product with an API, npm/PyPI SDKs, and an MCP server (listed in the official MCP registry).

- Added to the bottom of the category, format `[Name](Link) - Description.` matching existing entries.