### PR TITLE
Add Meridian Institute of AI to Learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 
 ## Learning resources
 
+- [Meridian Institute of AI](https://meridianinstituteai.com) - Free AI courses with certificates covering prompt engineering, AI agents, machine learning, and domain applications in finance, law, healthcare, and cybersecurity.
 - [Learn Prompting](https://learnprompting.org/) - A free, open source course on communicating with artificial intelligence.
 - [Prompt Engineering Guide](https://github.com/dair-ai/Prompt-Engineering-Guide) - Guide and resources for prompt engineering.
 - [ChatGPT prompt engineering for developers](https://www.deeplearning.ai/short-courses/chatgpt-prompt-engineering-for-developers/) - A short course by Isa Fulford (OpenAI) and Andrew Ng (DeepLearning.AI).


### PR DESCRIPTION
## What

Adding [Meridian Institute of AI](https://meridianinstituteai.com) to the Learning resources section.

## Why

Meridian is a structured, free AI education platform with 20 courses covering generative AI tools (ChatGPT, Claude, Gemini, Perplexity), prompt engineering, AI agents, and domain applications. Each course includes a verifiable certificate. Free to start.

## Fits the list because

Directly relevant to learning generative AI — covers the major models, prompting techniques, and agentic AI patterns that define the generative AI space.