### PR TITLE
Add Weco to Coding > Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [Weco](https://weco.ai) - Autoresearch platform that optimizes code — GPU kernels, ML models, feature engineering, and prompts — against an evaluation metric. [#opensource](https://github.com/WecoAI/weco-cli)
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [Weco](https://weco.ai) under Coding > Developer tools — an autoresearch platform that optimizes code (GPU kernels, ML models, prompts) against an evaluation metric. Core CLI is open-source ([weco-cli](https://github.com/WecoAI/weco-cli)). Thanks!