### PR TITLE
Add OpenDraft

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [ASReview](https://asreview.nl/) - Open-source AI-powered tool for systematic reviews, helping researchers screen large volumes of academic literature efficiently. [#opensource](https://github.com/asreview/asreview)
 - [Local Deep Research](https://github.com/LearningCircuit/local-deep-research) - A deep research tool for searching academic sources, the web, and private documents with local or cloud LLMs. [#opensource](https://github.com/LearningCircuit/local-deep-research)
 - [Rayyan](https://www.rayyan.ai/) - An AI-powered platform for managing systematic literature reviews with collaborative screening and data management tools.
+- [OpenDraft](https://openpaper.dev?utm_source=github&utm_medium=awesome_list&utm_campaign=awesome-generative-ai) - A multi-agent engine that drafts long-form research papers with citations verified against CrossRef, OpenAlex, Semantic Scholar, and arXiv. [#opensource](https://github.com/federicodeponte/opendraft)
 
 ### Leaderboards
 


### PR DESCRIPTION
Adds **OpenDraft** to the **Academia** section (bottom of category, per CONTRIBUTING).

OpenDraft is an open-source (MIT) multi-agent engine that drafts long-form academic papers and verifies every citation against CrossRef, OpenAlex, Semantic Scholar, and arXiv. It sits naturally next to the other open-source research tools already in this section (STORM, ASReview, Local Deep Research).

- GitHub: https://github.com/federicodeponte/opendraft
- License: MIT, actively maintained, well-documented
- Tagged `#opensource` per the section convention; format `[Name](Link) - Description.`

If it does not meet the Main List inclusion criteria, I'm happy for it to be placed in the Discoveries list instead.