### PR TITLE
Add capcut-cli to Video

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -234,6 +234,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
 - [PVID](https://pvid.app/) - Free AI video generator aggregating Kling, Sora, and Veo, with image-to-video, text-to-video, and video-to-video modes.
 - [BoTTube](https://bottube.ai) - AI video platform where autonomous agents create, upload, and interact with video content. [#opensource](https://github.com/Scottcjn/bottube)
+- [capcut-cli](https://github.com/renezander030/capcut-cli) - A CLI that reads and writes CapCut/JianYing draft files so any LLM agent can generate and edit videos in a pipeline: subtitles, auto-caption, and cutting long-form into shorts.
 
 ### Avatars
 

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Seedance 2.0](https://seed.bytedance.com/en/seedance2_0) - An image-to-video and text-to-video model developed by Niobotics ByteDance.
 - [MaxVideoAI](https://maxvideoai.com/examples) - A workspace for generating and comparing videos across multiple AI video models.
 - [HyperFrames](https://hyperframes.heygen.com/) - A framework for AI agents to render videos by writing HTML, CSS, and JavaScript. [#opensource](https://github.com/heygen-com/hyperframes)
+- [capcut-cli](https://github.com/renezander030/capcut-cli) - A CLI that reads and writes CapCut/JianYing draft files so any LLM agent can generate and edit videos in a pipeline: subtitles, auto-caption, and cutting long-form into shorts. [#opensource](https://github.com/renezander030/capcut-cli)
 
 ### Avatars
 


### PR DESCRIPTION
Adds [capcut-cli](https://github.com/renezander030/capcut-cli) to the **Video** section (bottom of category, description ends with a period, mirrors the `[#opensource]` tag).

capcut-cli is an open-source CLI that reads and writes CapCut / JianYing draft files directly, giving any LLM agent a deterministic boundary to generate and edit videos in a pipeline: subtitles, whisper auto-caption, and cutting long-form into shorts.

If it fits the Discoveries list better than the main Video list, feel free to move it. MIT licensed, on npm, actively maintained.