### PR TITLE
Add OpenPaper to Writing assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Postwise](https://postwise.ai/) - Write tweets, schedule posts and grow your following using AI.
 - [Copysmith](https://copysmith.ai/) - AI content creation solution for Enterprise & eCommerce.
 - [Humanize-Text](https://github.com/lynote-ai/humanize-text) - AI text humanizer with a multilingual rewriting pipeline and step-by-step examples. #opensource
+- [OpenPaper](https://openpaper.dev) - Open-source AI research-paper writer that drafts academic papers with citations verified against real databases (OpenAlex, Crossref, and Semantic Scholar).
 
 ### ChatGPT extensions
 


### PR DESCRIPTION
Adds [OpenPaper](https://openpaper.dev) to **Text → Writing assistants**.

OpenPaper is an open-source AI research-paper writer: a multi-agent pipeline drafts structured academic papers and verifies every citation against real academic databases (OpenAlex, Crossref, Semantic Scholar) so references are not hallucinated. Web app with a free daily tier; engine is MIT-licensed.

Follows the contributing format (`[ProjectName](Link) - Description.`) and is appended to the bottom of the category.