### PR TITLE
Add Pixo to the Video list

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Seedance 2.0](https://seed.bytedance.com/en/seedance2_0) - An image-to-video and text-to-video model developed by Niobotics ByteDance.
 - [MaxVideoAI](https://maxvideoai.com/examples) - A workspace for generating and comparing videos across multiple AI video models.
 - [HyperFrames](https://hyperframes.heygen.com/) - A framework for AI agents to render videos by writing HTML, CSS, and JavaScript. [#opensource](https://github.com/heygen-com/hyperframes)
+- [Pixo](https://pixo.video/) - Turn a story into a storyboard and generate it into a finished video, scene by scene.
 
 ### Avatars
 


### PR DESCRIPTION
Adds [Pixo](https://pixo.video/) to the **Video** section.

Pixo is an AI video generation tool that takes a story idea → storyboard → scene-by-scene generation → finished video, with agent-assisted editing. It fits alongside the other idea/text-to-video tools already listed (Runway, Pika, Luma, etc.).

Entry added to the bottom of the Video category per CONTRIBUTING.md, formatted as `[Name](Link) - Description.` — happy to move it to the Discoveries list if you feel that's a better fit.