### PR TITLE
Add SeaOtter / OtterScore to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [SeaOtter / OtterScore](https://seaotter.ai) - A hostile-by-default critic that grades AI agent output against your acceptance policy, returning a 0–100 OtterScore, a band (ship / route to fix / quarantine / block), localized flaws, and concrete fixes, via an eval API and hosted MCP server.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [SeaOtter / OtterScore](https://seaotter.ai) to **Coding → Developer tools**.

OtterScore is a hostile-by-default critic that grades AI agent output (code, docs, decisions — any modality) against your acceptance policy and returns a 0–100 score, a band (ship / route to fix / quarantine / block), localized flaws, and concrete fixes. It fits alongside the existing LLM-evaluation/observability tools in this section (Cleanlab, Opik, Langfuse, agenta). Available via an eval API and a hosted MCP server.

- Single entry, added to the bottom of its category per CONTRIBUTING.
- Format: `[ProjectName](Link) - Description.`
- No duplicate; description ends with a period.