### PR TITLE
Add app.nz to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [app.nz](https://app.nz/) - OpenAI- and Anthropic-compatible LLM gateway with an automatic model router across many providers.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [app.nz](https://app.nz/) to **Coding → Developer tools**, alongside the other LLM gateways/routers already listed (OpenRouter, Portkey, Bifrost, Together AI).

app.nz is a hosted, OpenAI- and Anthropic-compatible LLM gateway with an automatic model router (`app/auto`) across many providers — one API key for chat, embeddings, images, audio and search. Base URL `https://app.nz/v1`. Docs: https://app.nz/docs

Entry added to the bottom of the category per CONTRIBUTING.md.
