### PR TITLE
Add Neural Initiative to Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Morpher AI](https://morpher.com/ai) - Morpher AI delivers real-time insights and analysis for any market.
 - [Whimsical AI](https://whimsical.com/ai) - GPT-powered mind mapping, flowcharts, and visual tools for rapid idea development and process organization.
 - [Selfies with Sama](https://selfies-with-sama.vost.ai) - Grab a picture with a real-life billionaire!
+- [Neural Initiative](https://neuralinitiative.ai) - A persistent AI Dungeon Master for tabletop D&D 5e: solo or multiplayer campaigns with a coded rules engine, real dice, and lasting campaign memory.
 
 ## Learning resources
 


### PR DESCRIPTION
Adds Neural Initiative, a hosted AI Dungeon Master for D&D 5e (persistent campaign memory, a coded rules engine with real dice, voice narration, solo or multiplayer). It fits alongside AI Dungeon in **Other**.

Follows the `[Name](Link) - Description.` format, appended to the bottom of the category, no trailing whitespace.

Disclosure: I'm affiliated with the project.