### PR TITLE
Add Model Price Watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Morpher AI](https://morpher.com/ai) - Morpher AI delivers real-time insights and analysis for any market.
 - [Whimsical AI](https://whimsical.com/ai) - GPT-powered mind mapping, flowcharts, and visual tools for rapid idea development and process organization.
 - [Selfies with Sama](https://selfies-with-sama.vost.ai) - Grab a picture with a real-life billionaire!
+- [Model Price Watch](https://modelpricewatch.com) - Live, source-linked pricing for 150+ LLM APIs across 24 providers; every price links to the provider's official page. Free CORS-open JSON API.
 
 ## Learning resources
 


### PR DESCRIPTION
Adds Model Price Watch under **Other** — a free tracker of live LLM API pricing (150+ models / 24 providers), with every price linked to the provider's official pricing page, plus a free CORS-open JSON API.

Disclosure: I maintain the site — flagging per self-promotion norms; happy to adjust or drop if not a fit. Glad to relocate it (e.g. near a leaderboards/compare-pricing spot) if you'd prefer.