### PR TITLE
Add Orca

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Lovable](https://lovable.dev) - Conversational full-stack app generation, turning ideas into deployable code.
 - [aider](https://aider.chat/) - AI pair programming in your terminal, supporting multiple LLM providers. [#opensource](https://github.com/paul-gauthier/aider)
 - [Kilo](https://kilo.ai/) - Open-source AI coding assistant for VS Code, JetBrains, and the CLI. [#opensource](https://github.com/Kilo-Org/kilocode)
+- [Orca](https://onorca.dev) - An open-source IDE for orchestrating multiple AI coding agents (Claude Code, Codex, Cursor, Gemini, OpenCode) side-by-side, each in its own isolated git worktree. [#opensource](https://github.com/stablyai/orca)
 
 ### Developer tools
 


### PR DESCRIPTION
Adds **Orca** to `Coding → Coding Assistants`.

Orca is an open-source (MIT) desktop and mobile ADE for running a fleet of parallel AI coding agents — Claude Code, Codex, Cursor, Gemini, OpenCode and others — each in its own isolated git worktree, with a built-in terminal, source control, and SSH. It has ~8.6k GitHub stars (clears the 1k-star inclusion bar).

- Source: https://github.com/stablyai/orca
- Website: https://onorca.dev

Added to the bottom of the category with the `#opensource` tag, matching the existing format. Thanks!