### PR TITLE
Add MindGenius AI to Discoveries (Productivity)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -85,6 +85,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [SageCollab](https://sagecollab.com/) - SageCollab brings team collaboration features to generative AI.
 - [Worksheets.ai](https://www.worksheets.ai/) - Generate educational worksheets and lesson plans with AI.
 - [Recall](https://www.recall.it/) - A self-organizing knowledge base, where you can summarize and chat with any online content.
+- [MindGenius AI](https://github.com/xianjianlf2/MindGeniusAI) - An open-source AI agent that reads your PDFs and draws editable mind maps live, with a visible tool-calling loop, built-in RAG, and bring-your-own-key support.
 
 ### Meeting assistants
 - [Goelo](https://www.goelo.com/) - Goelo helps sales teams automatically fill their CRM by recording meetings to create summaries and generate a knowledge base.


### PR DESCRIPTION
Adds **MindGenius AI** to the Discoveries list under **Productivity**.

It's an open-source (MIT) AI agent named Hermas that reads your PDFs and draws editable mind maps live: a visible multi-step tool-calling loop (Vercel AI SDK v5), in-memory RAG, two-way canvas editing, and bring-your-own-key multi-provider support (OpenAI / Claude / DeepSeek / Kimi). Self-hostable as a single Docker image, with a live demo.

- Repo: https://github.com/xianjianlf2/MindGeniusAI
- Live demo: https://mindgenius.onrender.com

Added to the Discoveries list (not the Main List) since the project is below the 1,000-star threshold. Followed the `[ProjectName](Link) - Description.` format and added it to the bottom of the category.