### PR TITLE
Add khazad to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [khazad](https://github.com/GuglielmoCerri/khazad) - Transparent semantic cache for LLM API calls, powered by Redis Vector Sets. [#opensource](https://github.com/GuglielmoCerri/khazad)
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds **khazad** to the Developer tools section.

[khazad](https://github.com/GuglielmoCerri/khazad) - Transparent semantic cache for LLM API calls, powered by Redis Vector Sets.