### PR TITLE
docs: add Skill Hub to More lists section

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Awesome Music AI](https://github.com/steven2358/awesome-music-ai) - A curated list of AI tools for music composition, generation, and analysis.
 - [Awesome AI Market Maps](https://github.com/joylarkin/Awesome-AI-Market-Maps) - A curated list of AI market maps from 2026, 2025, and 2024, by [Joy Larkin](https://twitter.com/joy).
 - [Awesome RAG Production](https://github.com/Yigtwxx/Awesome-RAG-Production) - A curated list of tools and resources for building production RAG systems.
+- [Skill Hub — AI Agent Skills Navigator](https://skill.442595.xyz/) — 5,000+ curated AI agent skills across 20+ categories, from Claude Code, Cursor, Copilot, and open-source collections.
 
 ### Lists on ChatGPT
 


### PR DESCRIPTION
Added [Skill Hub](https://skill.442595.xyz/) — an AI Agent Skills Navigator with 5,000+ curated skills across 20+ categories.