### PR TITLE
Add ai-rulez and prompt-template to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [ai-rulez](https://github.com/Goldziher/ai-rulez) - Define your AI coding rules, agents, and MCP config once and generate native configs for 19+ tools (Claude, Cursor, Copilot, Codex, and more). [#opensource](https://github.com/Goldziher/ai-rulez)
+- [prompt-template](https://github.com/Goldziher/prompt-template) - Lightweight Python library for building typed, reusable LLM prompt templates. [#opensource](https://github.com/Goldziher/prompt-template)
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds two open-source developer tools:
- **ai-rulez** (121★) — write your AI coding rules/agents/MCP config once and generate native configs for 19+ tools (Claude, Cursor, Copilot, Codex, …).
- **prompt-template** (24★) — lightweight Python library for typed, reusable LLM prompt templates.
Both MIT-licensed.
