### PR TITLE
add remoteopenclaw mcp to discoveries developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -149,6 +149,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
+- [RemoteOpenClaw MCP](https://github.com/aidevelopers2/remoteopenclaw-mcp) - MCP server and CLI that searches 13,870+ MCP servers, 4,384+ skills, and plugins from your terminal or AI agent, no API key required. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
adds RemoteOpenClaw MCP to the Discoveries list under Coding > Developer tools.

it is an open source (MIT) MCP server and CLI that searches 13,870+ MCP servers, 4,384+ skills, and plugins from your terminal or AI agent, no API key required. added to Discoveries rather than the main list per the contribution guidelines, since the project is still early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)