### PR TITLE
Add AI Usage Ball to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [AI Usage Ball](https://aiusageball.com) - A macOS desktop widget to track remaining quotas for Claude, Codex, and Antigravity. [#opensource](https://github.com/aiusageball/ai-usage-ball)
 
 ### Playgrounds
 


### PR DESCRIPTION
Add AI Usage Ball. It is a macOS desktop widget to track remaining quotas for Claude, Codex, and Antigravity with liquid animated gauges.