### PR TITLE
Add llm-speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenRouter LLM Rankings](https://openrouter.ai/rankings) - Language models ranked and analyzed by usage across apps.
 - [SEAL LLM Leaderboard](https://labs.scale.com/leaderboard) - Expert-driven LLM benchmarks and updated AI model leaderboards.
 - [LLM Stats](https://llm-stats.com/) - Compare AI models across benchmarks, pricing, speed, and context window.
+- [llm-speed](https://llm-speed.com) - A crowdsourced, reproducible benchmark of LLM inference speed (tokens/sec, TTFT, latency) across hosted APIs, consumer GPUs, and Apple Silicon.
 
 ### Other text generators
 


### PR DESCRIPTION
Hi! Adding [llm-speed](https://llm-speed.com), a crowdsourced benchmark
of how fast LLMs actually run (decode tok/s, TTFT, latency percentiles)
across hosted APIs, consumer GPUs, and Apple Silicon under one
reproducible workload suite (`suite-v1`).

Why it fits this list:
- **Reproducible**: open-source CLI (`pipx install llm-speed`) runs the
  same workload pack on any machine; every published number links
  back to the run record that produced it.
- **Trust chain**: dual-domain SHA-256 sidecar (CDN + GitHub Releases),
  Apache-2.0, public source at github.com/meadow-kun/llm-speed.
- **Open data**: every submission is JWS-signed and queryable via
  `https://api.llm-speed.com/v1/results`.

Following existing format / position. Happy to adjust the blurb or
section if you'd prefer a different fit.
