### PR TITLE
Add Gokin to Coding Assistants (Discoveries)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -122,6 +122,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - CLI tool that translates natural-language prompts into shell commands and asks for confirmation before execution.
 - [Yume](https://github.com/aofp/yume) - Desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, and plugin system. #opensource
 - [Frontman](https://frontman.sh/) - A browser-based AI coding agent for editing frontend code with live app context. [#opensource](https://github.com/frontman-ai/frontman)
+- [Gokin](https://github.com/ginkida/gokin) - Terminal AI coding assistant that understands your codebase and runs shell, git, and file tasks from natural language, with cloud and local (Ollama) models. #opensource
 
 ### Developer tools
 


### PR DESCRIPTION
Adding Gokin, an open-source terminal AI coding assistant (Go). It works over your codebase with shell/git/file tools from natural language and supports both cloud providers and local models via Ollama. Placed in the Discoveries list under Coding Assistants, following the contribution guidelines. MIT-licensed, actively maintained.