### PR TITLE
Add AI Model Watch (Discoveries → Leaderboards)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -101,6 +101,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 - [Price Per Token](https://pricepertoken.com/) - A tool for comparing LLM API pricing, token usage, and model benchmarks.
 - [Rival](https://rival.tips) - Leaderboard ranking 200+ AI models based on blind A/B human preference votes.
+- [AI Model Watch](https://aimodelwatch.dev) - Tracks LLM prices, context windows, and deprecation dates across providers, updated daily. [#opensource](https://github.com/Khavel/ai-model-watch-data)
 
 ### Other text generators
 


### PR DESCRIPTION
Adding **[AI Model Watch](https://aimodelwatch.dev)** to the **Discoveries → Leaderboards** section.

**What it is:** a free site that tracks LLM prices, context windows, and — the part existing entries don't cover — **deprecation / end-of-life dates** across providers (OpenAI, Anthropic, Google, DeepSeek, Mistral, Alibaba, Amazon, etc.), refreshed daily. Sits naturally next to *Price Per Token* and *LLM Stats*, but adds model lifecycle/retirement tracking.

**Why Discoveries:** per CONTRIBUTING, the project doesn't yet meet the main-list threshold (1k+ followers), so I've placed it in the Discoveries list as the guidelines direct.

**Open component:** backed by an open, daily-updated dataset — https://github.com/Khavel/ai-model-watch-data (tagged `#opensource`).

Format checks: `[Name](link) - Description.` ✓ · appended to the bottom of the category ✓ · single line ✓ · description ends with a period ✓.