### PR TITLE
Add NameBuddy.ai (free AI domain name generator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Morpher AI](https://morpher.com/ai) - Morpher AI delivers real-time insights and analysis for any market.
 - [Whimsical AI](https://whimsical.com/ai) - GPT-powered mind mapping, flowcharts, and visual tools for rapid idea development and process organization.
 - [Selfies with Sama](https://selfies-with-sama.vost.ai) - Grab a picture with a real-life billionaire!
+- [NameBuddy.ai](https://namebuddy.ai/) - AI-generated domain names with live registry verification. Free, no affiliate links.
 
 ## Learning resources
 


### PR DESCRIPTION
Adding NameBuddy.ai to the list.

**What it is:** Free AI-powered domain name generator that verifies availability against live registry records (RDAP) before showing results. Never shows taken names.

**Why it fits this list:** Practical, free tool for the audience this list serves — built by an indie maker, no affiliate links anywhere, fully usable without an account.

**Site:** https://namebuddy.ai/

Happy to adjust the entry wording or section if you prefer. Thanks for maintaining this list!