### PR TITLE
Add ima2-gen (Image)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Reve Image](https://reve.com/) - A model trained from the ground up to excel at prompt adherence, aesthetics, and typography.
 - [Magnific](https://www.magnific.com/) - AI-powered design tools including image generation, background removal, and creative templates.
 - [FigureLabs](https://www.figurelabs.ai/) - An AI tool for generating publication-ready scientific figures in vector format from text descriptions or sketches.
+- [ima2-gen](https://github.com/lidge-jun/ima2-gen) - Generate images and video with OpenAI's GPT Image 2 from a CLI or local web UI — text-to-image, image-to-image, storyboard continuity, and canvas editing.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds **ima2-gen** (★462, author here) to **Image › Models** — a CLI + local web UI for OpenAI's GPT Image 2 (text-to-image, image-to-image, video, storyboard, canvas). Open-source, active, formatted to match.