### PR TITLE
Add Off Grid AI Desktop to Local LLM Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [RunThisLLM](https://runthisllm.com) - See which LLMs you can run on your hardware.
 - [Harbor](https://github.com/av/harbor) - A containerized toolkit for running local LLM backends, UIs, and supporting services with one command. #opensource
 - [off-grid-mobile](https://github.com/alichherawalla/off-grid-mobile-ai) - React Native app for running LLMs, vision models, and Stable Diffusion on-device on iOS and Android without internet access. #opensource
+- [Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop) - Private, local-first macOS app for LLM chat, Stable Diffusion image generation, whisper transcription, and personal memory search, fully on-device via llama.cpp. #opensource
 
 ## Agents
 


### PR DESCRIPTION
## What
Adds [Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop) to **### Local LLM Deployment**, directly alongside its sibling off-grid-mobile which is already listed there, and next to Jan, LM Studio, Ollama, and Open WebUI.

## About
Open-source (AGPL-3.0) macOS app that runs a full local AI suite on your Mac - nothing leaves the device.
- Local LLM chat via llama.cpp
- On-device Stable Diffusion image generation
- Whisper voice transcription and dictation
- Personal memory / RAG search over your own data
- No account, no telemetry, no cloud

Disclosure: I'm involved with the project.