### PR TITLE
Add VibeKit.bot to Coding Assistants (Discoveries)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -122,6 +122,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - CLI tool that translates natural-language prompts into shell commands and asks for confirmation before execution.
 - [Yume](https://github.com/aofp/yume) - Desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, and plugin system. #opensource
 - [Frontman](https://frontman.sh/) - A browser-based AI coding agent for editing frontend code with live app context. [#opensource](https://github.com/frontman-ai/frontman)
+- [VibeKit.bot](https://vibekit.bot) - Persistent AI coding agents that build, host, and keep improving apps on a live domain, driven from a phone, Telegram, or the CLI.
 
 ### Developer tools
 


### PR DESCRIPTION
Adds **VibeKit.bot** to the Discoveries list, Coding → Coding Assistants (bottom of the section, per the guidelines).

VibeKit gives every app its own persistent AI coding agent that builds, hosts (live `*.vibekit.bot` domain included; optional database add-on), and keeps improving the app over time — driven from a phone, the web, Telegram, or the CLI. BYOK for Claude/OpenAI or pay-as-you-go. Native iOS app on the App Store: https://apps.apple.com/us/app/vibekit-agent-devops/id6760206636

Submitted to Discoveries (not the Main List) per the inclusion criteria. Quick disambiguation: this is **VibeKit.bot**, unrelated to the discontinued `superagent-ai/vibekit` npm SDK.

Disclosure: I'm the maker.