### PR TITLE
Add TierUp to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [TierUp](https://tierup.ai) - An OpenAI-compatible API that routes by performance tier (speed/balance/intelligence/reasoning) instead of model name; tier mappings upgrade server-side as better models ship.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds TierUp to the Developer tools section. OpenAI-compatible LLM API that abstracts model choice into 4 performance tiers. Disclosure: I'm the founder. Entry follows the existing format; happy to adjust or withdraw if commercial entries aren't wanted here — and if it's too early-stage for the main list, I'm glad to move it to DISCOVERIES.md instead per your contributing guide.