### PR TITLE
Add ofox to Discoveries developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [ofox](https://ofox.ai) - A unified LLM gateway with one API key for 100+ models, speaking the OpenAI, Anthropic, and Gemini protocols natively.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds ofox to the Discoveries list, under Coding → Developer tools.

ofox is a unified LLM gateway: one API key for 100+ models, speaking the OpenAI, Anthropic, and Gemini protocols natively, so existing SDKs work by changing only the base URL.

I originally opened this against the main list. Re-reading the contribution guidelines, the project doesn't yet meet the inclusion criteria there, so I've retargeted the change to DISCOVERIES.md. Happy to resubmit for the main list later if it grows.
