### PR TITLE
Add ClawRouters to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [ClawRouters](https://www.clawrouters.com/) - A smart LLM router that classifies each request and routes it to the cheapest model that maintains quality, with a free BYOK tier and an OpenAI-compatible API.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [ClawRouters](https://www.clawrouters.com/) — a smart LLM router that classifies each request and routes it to the cheapest model that maintains quality. Free BYOK tier, OpenAI-compatible API (one base-URL change), 50+ models.

Follows the formatting guidelines: added to the bottom of the Developer tools category, concise description ending with a period.

Disclosure: I'm affiliated with the project — submitting under criterion 2 (maintainer's judgment); happy to have it considered for the Discovery list instead if that's a better fit.