### PR TITLE
Add BuildingAI AI Readiness Assessment (free, no signup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [BuildingAI — AI Readiness Assessment](https://buildingai.in/tools/ai-readiness-assessment) - Score your organization's enterprise-AI readiness across 8 dimensions in 2 minutes. Free, no signup.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds BuildingAI's free Enterprise AI Readiness Assessment under Developer tools. It's a genuinely free, working web tool (no signup) that scores AI readiness across 8 dimensions — relevant to this list's audience. Followed the existing entry format and alphabetical ordering. Thanks for maintaining this list!
