### PR TITLE
Add time-ledger to Productivity section

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -85,6 +85,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [SageCollab](https://sagecollab.com/) - SageCollab brings team collaboration features to generative AI.
 - [Worksheets.ai](https://www.worksheets.ai/) - Generate educational worksheets and lesson plans with AI.
 - [Recall](https://www.recall.it/) - A self-organizing knowledge base, where you can summarize and chat with any online content.
+- [time-ledger](https://github.com/cruisekkk/time-ledger) - Natural-language time tracking for Claude and ChatGPT that parses plain-language activity reports into your own Notion database, asking instead of guessing when unsure. #opensource
 
 ### Meeting assistants
 - [Goelo](https://www.goelo.com/) - Goelo helps sales teams automatically fill their CRM by recording meetings to create summaries and generate a knowledge base.


### PR DESCRIPTION
Adds [time-ledger](https://github.com/cruisekkk/time-ledger) to Discoveries → Text → Productivity — natural-language time tracking for Claude and ChatGPT that parses plain-language activity reports into the user's own Notion database, asking instead of guessing when unsure. Open source (MIT), bilingual EN/中文, free Notion template included. (Submitting to Discoveries per CONTRIBUTING since the project is below the main-list follower threshold. I'm the author.)