### PR TITLE
Add Oats to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -90,6 +90,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Goelo](https://www.goelo.com/) - Goelo helps sales teams automatically fill their CRM by recording meetings to create summaries and generate a knowledge base.
 - [Equal Time](https://equaltime.io/) - An AI meeting assistant that transcribes calls, generates summaries, and tracks participation metrics for more inclusive meetings.
 - [MeetGeek](https://meetgeek.ai) - An AI meeting assistant that automatically records, transcribes, and summarizes meetings.
+- [OATS](https://ariso.ai/oats) - Open-source macOS meeting-notes app with live transcription, speaker labels, AI summaries, and optional on-device processing. [#opensource](https://github.com/ariso-ai/oats).
 
 ### Academia
 


### PR DESCRIPTION
Adds Oats to Discoveries > Meeting assistants. Oats is an open-source macOS app for live meeting transcription, speaker labels, AI summaries, and optional on-device processing.

Local checks:
- git diff --check
- curl -I -L --fail https://ariso.ai/oats
- curl -I -L --fail https://github.com/ariso-ai/oats

Note: The full local awesome_bot run reports pre-existing unrelated README/DISCOVERIES failures; the new Oats links return HTTP 200.
