### PR TITLE
Add Humla

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Loopin AI](https://www.loopinhq.com/) - Loopin is a collaborative meeting workspace that not only enables you to record, transcribe & summaries meetings using AI, but also enables you to auto-organise meeting notes on top of your calendar.
 - [Read AI](https://www.read.ai/) - An AI copilot for wherever you work, making your meetings, emails, and messages more productive with summaries, content discovery, and recommendations.
 - [Fireflies.ai](https://fireflies.ai) - Transcribe, summarize, search, and analyze all your team conversations.
+- [Humla](https://humla.team) - An open-source macOS app that records meetings with no bot in the call and transcribes and summarizes on-device.
 
 ### Academia
 


### PR DESCRIPTION
Adds [Humla](https://humla.team) to **Text → Meeting assistants**.

Humla is a free, open-source (MIT) macOS meeting assistant. Unlike the other tools in this section, it records the mic + system audio through macOS with **no bot joining the call**, and can transcribe and summarize entirely **on-device** with Whisper (or a bring-your-own key) — no account, no telemetry. A local-first, open counterpart to Otter/Fireflies/Read AI.

Source: https://github.com/michaelwilhelmsen/humla