### PR TITLE
Add Tree Ring Memory to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -175,6 +175,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 - [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
+- [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - Local-first memory lifecycle framework for AI agents with Rust command-line recall, audit, consolidation, and forgetting.
 
 ### Custom assistants
 


### PR DESCRIPTION

## Summary
- Adds Tree Ring Memory to `DISCOVERIES.md` under Agents / Autonomous agents.
- Uses the Discoveries list rather than the main list because Tree Ring is an up-and-coming open-source project and does not claim the main-list 1,000-follower threshold.
- Disclosure: I maintain Tree Ring Memory.

## Validation
- Checked upstream PRs and issues for existing Tree Ring / tree-ring / TerminallyLazy references; none found.
- Verified the Tree Ring Memory GitHub link returns HTTP 200.
- Confirmed the Tree Ring Memory row appears exactly once in DISCOVERIES.md and not in README.md.
- Ran git diff --check.
- Ran npx --yes awesome-lint DISCOVERIES.md; it still reports pre-existing Discoveries issues, including the existing Network-AI row at line 177. The added Tree Ring row follows the stated contribution format and ends with a period.
