### PR TITLE
Add Podframes to discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -225,6 +225,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [Podframes](https://github.com/Jellypod-Inc/podframes) - Open-source local studio and CLI for turning a topic into a two-host AI podcast video with mixed TTS voices, lip-synced avatars, captions, b-roll, and MP4 rendering. #opensource
 
 ### Avatars
 


### PR DESCRIPTION
Adds Podframes to the Discoveries video section, following the contribution guidelines for projects that are useful but not yet suited for the main list's follower threshold.