### PR TITLE
Add StackPicks to More lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,3 +477,4 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [FlowGPT](https://flowgpt.com/) - Amplify your workflow with the best prompts.
 - [ChatGPT Prompts for Data Science](https://github.com/travistangvh/ChatGPT-Data-Science-Prompts) - A repository of useful data science prompts for ChatGPT.
 - [Awesome ChatGPT](https://github.com/sindresorhus/awesome-chatgpt) - Another awesome list for ChatGPT.
+- [StackPicks](https://stackpicks.dev) - Curated open-source AI dev tools directory with opinionated curator takes on tradeoffs, "use this if / skip if" guidance, and daily-refreshed GitHub stats.


### PR DESCRIPTION
## What

Adding StackPicks (https://stackpicks.dev) to the "More lists" section.

## Why it fits

StackPicks is a curated dev tools directory covering AI coding, MCP, agent frameworks, RAG stacks, and adjacent open-source tooling. Every entry has:
- Hand-written curator take on tradeoffs (not just stars)
- "Use this if / Skip if" guidance
- Daily-refreshed GitHub stats

Follows the "list of lists" theme of this section.

## Checklist

- [x] Placed in "More lists"
- [x] Description follows one-sentence convention
- [x] Site is live
