### PR TITLE
Add LLMGraph

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -149,6 +149,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
+- [LLMGraph](https://llmgraph.ai) - No-code visual builder for LLM/AI workflows: turn your docs and models into RAG chatbots and AI agents, then deploy each to a REST API and an embeddable chat widget in one click.
 
 ### Playgrounds
 


### PR DESCRIPTION
LLMGraph (https://llmgraph.ai) is a no-code visual builder for LLM/AI workflows: turn your docs and models into RAG chatbots and AI agents, then deploy each to a REST API and an embeddable chat widget in one click.

As a commercial SaaS (14-day trial), it fits the **Discoveries** list rather than the Main List, so I added it to the bottom of **Coding > Developer tools** in DISCOVERIES.md, matching the list's `[Name](link) - Description.` format (single entry, no reordering).