### PR TITLE
Add Sparkiz to Discoveries → Video

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -225,6 +225,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [Sparkiz](https://sparkiz.ai/) - Turns a product page or photo into a UGC-style video ad with an AI presenter, voiceover, captions, and music.
 
 ### Avatars
 


### PR DESCRIPTION
Adds **Sparkiz** ([sparkiz.ai](https://sparkiz.ai/)) to the **Discoveries → Video** list.

Sparkiz is an AI video-ad generator — it turns a product page or photo into a UGC-style video ad with an AI presenter, voiceover, captions, and music (Hebrew / English / Russian). It sits naturally alongside the other link/text-to-video tools already in this section (invideo AI, TopView, VideoGen).

- Live product, actively maintained.
- Entry follows the `[Name](link) - Description.` format and is appended to the bottom of the Video section.
- Placed in **Discoveries** (up-and-coming) per CONTRIBUTING, not the Main List.