### PR TITLE
Add localmodel.run to Local LLM Deployment (Discoveries)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -155,6 +155,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 ### Local LLM Deployment
 
 - [Minima](https://github.com/dmayboroda/minima) - On-premises RAG with configurable Docker containers. #opensource
+- [localmodel.run](https://localmodel.run) - Database mapping RAM and VRAM requirements for 153 local models across 40 devices, with every spec sourced to HuggingFace or Ollama. [#opensource](https://github.com/ansumanshah/localmodel.run)
 
 ## Agents
 


### PR DESCRIPTION
Adding localmodel.run to the Local LLM Deployment section of DISCOVERIES.md.

It is a free database that answers whether a local AI model fits a given machine: 153 models (text plus image, video and audio) across 40 devices (Apple Silicon, NVIDIA/AMD GPUs, iPhone, Android, CPU-only), with the memory math (weights + KV cache + overhead) shown per pair and every number linked to its primary source (HuggingFace GGUF repo, Ollama tag, or vendor spec). No account, no ads. Code is MIT, data is CC BY 4.0: https://github.com/ansumanshah/localmodel.run

Live demo as a HuggingFace Space: https://huggingface.co/spaces/ansumanshah/can-i-run-it-locally

Disclosure: I am the author. Entry added at the bottom of the category, description ends in a period, per the contribution guidelines.