### PR TITLE
Add patina to discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -67,6 +67,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [LogicBalls](https://logicballs.com/) - An AI writing tool for generating blog posts, ads, emails, and social media content. Includes a prompt library.
 - [Publish7](https://publish7.com/) - Agentic platform for digital marketing.
 - [WordLift Agent](https://wordlift.io/agent/) - AI agent for SEO tasks such as product descriptions, internal linking, and SERP analysis.
+- [patina](https://github.com/devswha/patina) - Open-source CLI and agent skill that audits and rewrites AI-sounding writing patterns while preserving meaning. #opensource
 
 ### ChatGPT extensions
 


### PR DESCRIPTION
Adds patina to the Discoveries writing assistants section. I maintain patina, so this is a self-submission.

This targets Discoveries rather than the main list because patina is under the 1,000-star threshold in the contribution guidelines.

---
Note: this resubmits #928, which was auto-closed on 2026-06-21 when its source fork was deleted in an account cleanup — it was not closed by review. The entry itself is unchanged.