### PR TITLE
Add DevIntern to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [DevIntern](https://devintern.com/) - Turns Jira, Linear, Trello, Asana, Azure DevOps and GitHub Issues tickets into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode).
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds DevIntern to Coding > Developer tools.

DevIntern turns task-tracker tickets (Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues) into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode) with your own model keys. Source-available (FSL): https://github.com/getdevintern/devintern

- Entry added to the bottom of its category, format `[ProjectName](Link) - Description.`
- Actively maintained and documented (https://devintern.com/docs)
- No `#opensource` tag since the license is FSL (source-available), not OSI open source