### PR TITLE
Add MCPlato to autonomous agent discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -175,6 +175,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 - [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
+- [MCPlato](https://mcplato.com/) - A local-first desktop AI workspace that keeps files, conversations, workspace-scoped MCP tools, and parallel agent sessions attached to persistent project directories.
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds MCPlato under Discoveries → Autonomous agents.

MCPlato is a local-first desktop AI workspace that keeps files, conversations, workspace-scoped MCP tools, and parallel agent sessions attached to persistent project directories.