### PR TITLE
Add Nora to Developer tools discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -149,6 +149,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
+- [Nora](https://github.com/solomon2773/nora) - A self-hosted control plane for deploying, monitoring, and operating OpenClaw and Hermes AI agents on Docker or Kubernetes. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
## Summary

- Add Nora to `DISCOVERIES.md` under Coding → Developer tools.
- Describe its self-hosted OpenClaw and Hermes agent operations scope.

## Why it fits

Nora is an Apache-2.0, actively maintained, documented tool for deploying, monitoring, and operating generative AI agents on Docker or Kubernetes. Because it is an early-stage project below the Main List's 1,000-follower criterion, this contribution targets the Discoveries list as the contribution guide directs.

## Checks

- The official GitHub link resolves.
- The entry uses the required concise format and is appended to the relevant category.
- I searched the repository and open pull requests and found no existing Nora entry.