### PR TITLE
Add SAGE - Token compression CLI for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [SAGE](https://github.com/PsYcGoD/sage) - An open-source CLI wrapper that compresses terminal output for AI coding agents, saving 97%+ tokens with intelligent filtering of test logs, build output, and stack traces. [#opensource](https://github.com/PsYcGoD/sage)
 
 ### Playgrounds
 


### PR DESCRIPTION
Hi! Adding SAGE to the Developer tools section.\n\nSAGE is an open-source, local-first CLI wrapper and MCP server that compresses terminal output before it enters AI coding-agent context. Install with pip install psycgod-sage, run commands with sage run -- <command>, or use npx -y psycgod-sage run -- <command> when Python is unavailable.\n\nCurrent distribution proof: PyPI, npm/npx, official MCP Registry, and Glama hosted build/release. Metrics are SQLite-backed; current public proof shows 15,000+ commands with 97%+ aggregate compression. Raw command output stays local unless optional telemetry/auth is configured. Thanks for considering!