### PR TITLE
Add ToolMagpie (live-verified AI agent directory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 ### Other text generators
 
 - [EmailTriager](https://www.emailtriager.com/) - Use AI to automatically draft email replies in the background.
+- [ToolMagpie](https://toolmagpie.com) - Live-verified directory of AI agents (customer service, sales, coding, no-code builders, MCP servers, automation) that auto-flags dead tools, with side-by-side comparisons and honest pricing.
 - [AI Poem Generator](https://www.aipoemgenerator.org) - AI Poem Generator writes a beautiful rhyming poem for you on any subject, given a text prompt.
 
 ## Coding


### PR DESCRIPTION
Adds [ToolMagpie](https://toolmagpie.com) — a live-verified directory of AI agents (customer service, sales, coding, no-code builders, MCP servers, automation) that auto-flags dead tools with weekly link checks, plus side-by-side comparisons and honest pricing. Thanks for maintaining this list!