### PR TITLE
Add Requesty

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [Requesty](https://requesty.ai/) - An LLM gateway providing a unified OpenAI-compatible API to 400+ models, with smart routing, fallbacks, caching, and cost tracking.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [Requesty](https://requesty.ai/) to the Tools section.

Requesty is an LLM gateway that provides a unified OpenAI-compatible API to 400+ models, with smart routing, fallbacks, caching, and cost tracking, the same category as the existing OpenRouter, Portkey, and Bifrost entries.

- Entry added at the bottom of the Tools category, per CONTRIBUTING.md.
- Format `[ProjectName](Link) - Description.` with the description ending in a period; passes `awesome-lint` (no new errors on the added line).
- Meets inclusion criterion 1 (widely used, 1,000+ followers).

Disclosure: I work at Requesty.

