### PR TITLE
Add iaVideo.pt to Video

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -225,6 +225,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [iaVideo.pt](https://iavideo.pt) - A Portuguese AI video platform with 12 models (Runway, Kling, Veo 3, Sora) for text- and image-to-video, dubbing, and lip sync.
 
 ### Avatars
 


### PR DESCRIPTION
Adds iaVideo.pt to the Video section — a European-Portuguese AI video platform for text- and image-to-video across 12 models (Runway, Kling, Google Veo 3, OpenAI Sora, Luma), with multilingual dubbing, AI storyboard and lip sync, and a free plan.

As an up-and-coming project it's placed in the Discoveries list per the contributing guidelines (not the main list). The entry is added at the bottom of the Video category and matches the existing format. Thanks for maintaining this awesome list!