### PR TITLE
Add Agent Teams AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [Agent Teams AI](https://github.com/777genius/agent-teams-ai) - An open-source desktop orchestrator for autonomous coding-agent teams with task delegation, inter-agent messaging, a Kanban board, and code review across multiple agent runtimes. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
## Summary

Add Agent Teams AI to the Autonomous agents section.

## Why

The project is open source, actively maintained, and has more than 1,000 GitHub stars. It provides a desktop orchestrator for autonomous coding-agent teams with task delegation, messaging, Kanban, and code review.

## Validation

- Verified the project link
- Checked for an existing entry and open pull request
- Ran `git diff --check`

Disclosure: I maintain Agent Teams AI.