### PR TITLE
Add AgentCeres

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [AgentCeres](https://agentceres.com) - An AI growth team that researches competitors, drafts marketing content, and plans campaigns for small SaaS teams.
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds [AgentCeres](https://agentceres.com) to the Agents > Autonomous agents section, alongside other AI-agent SaaS products like Sauna, AgentMail, and Openwork. AgentCeres is an AI growth team of agents that research competitors, draft SEO/social content, and plan marketing campaigns for small SaaS teams, with human approval on outbound actions.
