### PR TITLE
Add Tura to coding discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -122,6 +122,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - CLI tool that translates natural-language prompts into shell commands and asks for confirmation before execution.
 - [Yume](https://github.com/aofp/yume) - Desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, and plugin system. #opensource
 - [Frontman](https://frontman.sh/) - A browser-based AI coding agent for editing frontend code with live app context. [#opensource](https://github.com/frontman-ai/frontman)
+- [Tura](https://github.com/Tura-AI/tura) - Local-first coding agent with CLI, TUI, and GUI interfaces, project rules, checkpoints, built-in verification, and public benchmarks. #opensource
 
 ### Developer tools
 


### PR DESCRIPTION
Adds Tura to **DISCOVERIES.md → Coding → Coding Assistants**, following the repository's guidance for projects that do not meet the Main List's 1,000-follower threshold.

Tura is an actively maintained and documented open-source coding agent. It provides CLI, TUI, and GUI interfaces, project-scoped rules, checkpoints, built-in verification, and reproducible public benchmarks.

The entry is at the bottom of the category, uses the required `[Project](Link) - Description.` format, ends with a period, and `git diff --check` passes.