### PR TITLE
Add goose-skills to Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Morpher AI](https://morpher.com/ai) - Morpher AI delivers real-time insights and analysis for any market.
 - [Whimsical AI](https://whimsical.com/ai) - GPT-powered mind mapping, flowcharts, and visual tools for rapid idea development and process organization.
 - [Selfies with Sama](https://selfies-with-sama.vost.ai) - Grab a picture with a real-life billionaire!
+- [goose-skills](https://github.com/gooseworks-ai/goose-skills) - An open-source library of 125 growth and GTM agent skills for ads, content, lead generation, outreach and SEO, for Claude Code, Codex and Cursor. #opensource
 
 ## Learning resources
 


### PR DESCRIPTION
Adds [goose-skills](https://github.com/gooseworks-ai/goose-skills) to the bottom of the **Other** section.

Open-source (MIT) library of 125 growth/GTM agent skills — ads, content, lead generation, outreach, competitive intelligence, monitoring, research, SEO — for Claude Code, Codex, and Cursor.

**Inclusion criteria:** meets the 1,000+ followers bar (1,000+ GitHub stars), actively maintained (daily commits), documented per-skill (SKILL.md metadata contract + CLI installer).

— Himanshu Bamoria, co-founder @ [GooseWorks](https://gooseworks.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)