### PR TITLE
Add squirrelscan to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [squirrelscan](https://squirrelscan.com/) - A website QA tool for coding agents that audits SEO, performance, security, and accessibility with 260+ rules and returns exact fixes, via CLI, cloud, or MCP.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [squirrelscan](https://squirrelscan.com/) to **Coding > Developer tools**.

squirrelscan is a website QA tool for coding agents that audits SEO, performance, security, and accessibility with 260+ rules and returns exact fixes, via CLI, cloud, or MCP. It fits alongside the agent/LLM developer tooling already listed (Repomix, Gitingest, Model Context Protocol).

- Appended to the bottom of the category per CONTRIBUTING.
- Uses the `[ProjectName](Link) - Description.` format, ending with a period.