### PR TITLE
Add AI Buddy to ChatGPT extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [AI Prompt Genius](https://chromewebstore.google.com/detail/ai-prompt-genius/jjdnakkfjnnbbckhifcfchagnpofjffo) - Discover, share, import, and use the best prompts for ChatGPT & save your chat history locally.
 - [ShareGPT](https://sharegpt.com/) - Share your ChatGPT conversations and explore conversations shared by others.
 - [Merlin](https://www.getmerlin.in/) - ChatGPT Plus extension on all websites.
+- [AI Buddy](https://chromewebstore.google.com/detail/ai-buddy/eigpaeoigklelmfgnkljhbjjbpohenpn) - Open-source Chrome side panel that sends selected text or annotated screenshots to ChatGPT, Claude, Gemini, DeepSeek, Copilot, WhatsApp, Telegram, or Discord. 10 starter scenarios (Explain, Translate, Summarize, Debug Code, etc.). No backend, your accounts only.
 - [Jetwriter](https://jetwriter.ai/) - AI writing assistant for Chrome, desktop, and mobile.
 - [ChatGPT for Jupyter](https://github.com/TiesdeKok/chat-gpt-jupyter-extension) - Add various helper functions in Jupyter Notebooks and Jupyter Lab, powered by ChatGPT.
 - [editGPT](https://www.editgpt.app/) - Easily proofread, edit, and track changes to your content in chatGPT.


### PR DESCRIPTION
Adds AI Buddy to the **ChatGPT extensions** section.

AI Buddy is an open-source Chrome side panel that sends selected text or annotated screenshots to ChatGPT, Claude, Gemini, DeepSeek, Copilot, WhatsApp, Telegram, or Discord.

## Why this section

Same category as Merlin / WebChatGPT / YouTube Summary with ChatGPT / editGPT (Chrome extensions that send selected content to AI for processing).

## Differentiation vs existing entries

- **No backend / no own model** — uses your existing accounts (no subscription, no data through third party)
- **Multi-platform**: 6 AI chat (ChatGPT / Claude / Gemini / DeepSeek / Copilot / Copilot Enterprise) + 3 messaging (WhatsApp / Telegram / Discord)
- **10 starter scenarios** vs ad-hoc prompts (Explain / Translate / Summarize / Draft Reply / Polish / Brainstorm / Debug Code / Write Tests / etc.)
- **Screenshot annotation** (crop / highlight / blur / draw arrows / labels) → send to AI for visual review
- **Per-platform send behavior**: AI platforms auto-submit, messaging apps draft-only

## Links

- Chrome Web Store: https://chromewebstore.google.com/detail/ai-buddy/eigpaeoigklelmfgnkljhbjjbpohenpn
- GitHub: https://github.com/mnbqwe10/ai_buddy (MIT, 61 commits)