### PR TITLE
Add Markstream to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [Markstream](https://markstream.simonhe.me/) - An open-source streaming Markdown renderer for AI chat interfaces, with incomplete-token handling and packages for Vue, React, Svelte, and Angular. [#opensource](https://github.com/Simon-He95/markstream-vue).
 
 ### Playgrounds
 


### PR DESCRIPTION
## Summary

Add Markstream to the **Developer tools** section.

Markstream is an open-source streaming Markdown renderer built for AI chat interfaces. It keeps incomplete Markdown usable while model tokens arrive and provides packages for Vue/Nuxt, React/Next.js, Svelte, and Angular, with Mermaid, KaTeX, syntax highlighting, safe HTML, and SSR support.

## Inclusion criteria

- The project currently has about 2.7k GitHub stars, above the main-list threshold.
- It is actively maintained and documented at https://markstream.simonhe.me/.
- I searched the README, Discoveries list, issues, and pull requests and found no existing Markstream entry or submission.
- The entry follows the requested format and is appended to the relevant category.

Disclosure: I maintain Markstream. Thank you for considering it!
