### PR TITLE
Add VibeVoice Studio to Audio > Text-to-speech

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -237,6 +237,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Deepgram](https://deepgram.com/) - Real-time speech recognition and understanding with advanced AI.
 - [Kveeky](https://kveeky.com) - An AI text-to-speech tool for generating voiceovers with 100+ natural-sounding voices.
 - [Voice Clone](https://voice-clone.org/) - Voice cloning tool with text-to-speech capabilities. [#opensource](https://github.com/tanchaowen84/voice-clone)
+- [VibeVoice Studio](https://voicestudio.msrbuilds.com) - Self-hosted web studio for the VibeVoice text-to-speech model, for multi-speaker podcasts and voiceovers with voice cloning. [#opensource](https://github.com/msrbuilds/voice-studio)
 
 ### Speech-to-text
 


### PR DESCRIPTION
Adds VibeVoice Studio to the Discoveries list under Audio > Text-to-speech.

VibeVoice Studio is an MIT-licensed, self-hosted web studio for the VibeVoice text-to-speech model - a multi-speaker podcast/voiceover editor with voice cloning that runs fully offline. Placed in Discoveries as an up-and-coming project per the contributing guidelines (single line appended to the bottom of the subsection).

Repo: https://github.com/msrbuilds/voice-studio
Site: https://voicestudio.msrbuilds.com