### PR TITLE
Add PulseGate to More lists

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -289,5 +289,6 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Awesome AI Software Development Agents](https://github.com/flatlogic/awesome-ai-software-development-agents) - Curated list of AI agents designed for software development tasks.
 - [MODELDROP](https://modeldrop.fyi/) - A community tracker for new generative media AI model releases.
 - [MyVibe](https://www.myvibe.so) - A feed for discovering and sharing AI-created web apps, demos, and interactive projects.
+- [PulseGate](https://www.pulsegate.ai) - Live index of AI-era software, tracking ~175k apps, models, agents and infrastructure tools as they ship.
 
 ### Lists on ChatGPT


### PR DESCRIPTION
Adds PulseGate to ## More lists (DISCOVERIES.md).

Disclosure: I'm from the PulseGate team (Dymaxio s.r.o., Prague).

PulseGate (pulsegate.ai) is a live index of AI-era software — apps, models, agents and infrastructure — currently ~175,000 tracked, indexed as they ship rather than on a curation cycle. No editorial gate, no ranking, no pay-to-play. Free public stats JSON (/api/stats/public), RSS feeds, and an embeddable widget; methodology and a copy-paste citation at pulsegate.ai/press.

Fits More lists as a live, no-gatekeeper discovery resource alongside MODELDROP and MyVibe.