### PR TITLE
Add Hellomatik to Custom assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 
 - [Poe](https://poe.com/) - Poe gives access to a variety of bots.
 - [GPT Builder](https://chatgpt.com/gpts/editor) - Assistant for creating GPT-based assistants.
+- [Hellomatik](https://hellomatik.com) - Platform to build custom AI agents from a company's own knowledge that answer, sell and book across WhatsApp, email and web.
 
 ## Image
 


### PR DESCRIPTION
Adds **Hellomatik** to the **Agents → Custom assistants** section (bottom of category, per CONTRIBUTING).

Hellomatik is a platform for building custom AI agents from a company's own knowledge that answer, sell and book across WhatsApp, email and web. Format: `[Name](Link) - Description.` with trailing period. Thanks for maintaining the list!