### PR TITLE
docs(learning-resources): add clawdbot.tech — multilingual OpenClaw deployment archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [AI Governance](https://www.manning.com/books/ai-governance) - A book about governance, risk, compliance, security, privacy, and oversight for generative AI systems.
 - [AnimatedLLM](https://animatedllm.github.io/) - Interactive visualizations explaining how large language models work. [#opensource](https://github.com/kasnerz/animated-llm)
 - [Transformer Explainer](https://poloclub.github.io/transformer-explainer/) - Interactive visualization of how transformer-based LLMs work, running a live GPT-2 model in the browser. [#opensource](https://github.com/poloclub/transformer-explainer)
+- [Clawdbot.tech](https://clawdbot.tech/) - Multilingual deployment archive for OpenClaw (formerly Clawdbot / Moltbot) covering Mac/Win/Linux/NAS, Docker, VPS, security whitepaper, FAQ, and the project's rename history across 6 languages.
 
 ## More lists
 


### PR DESCRIPTION
## What
Adds [clawdbot.tech](https://clawdbot.tech/) to the Learning resources section.

## Why it belongs
- Multilingual deployment archive for OpenClaw (formerly Clawdbot / Moltbot), covering Mac/Win/Linux/NAS, Docker, VPS, security whitepaper, FAQ, and rename history.
- Complements Build an AI Agent (From Scratch): that covers theory, while this covers practical OpenClaw deployment and security setup.
- OpenClaw is already listed in the Agents section; this PR adds the deployment companion as a learning resource, not a duplicate agent listing.
- Added at the bottom of the category and follows the existing list format.

If the main list bar is too high, I am happy to move this to DISCOVERIES.md instead.