### PR TITLE
Add VerdictBits VRAM Calculator (Local LLM Deployment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [LLM](https://llm.datasette.io/) - A CLI utility and Python library for interacting with Large Language Models, remote and local. [#opensource](https://github.com/simonw/llm)
 - [LM Studio](https://lmstudio.ai) - Download and run local LLMs on your computer.
 - [RunThisLLM](https://runthisllm.com) - See which LLMs you can run on your hardware.
+- [VerdictBits VRAM Calculator](https://verdictbits.com/reviews/llm-vram-calculator/) - Estimate the GPU VRAM needed to run an LLM locally by model size, quantization and context length, and see which GPUs fit.
 - [Harbor](https://github.com/av/harbor) - A containerized toolkit for running local LLM backends, UIs, and supporting services with one command. #opensource
 - [off-grid-mobile](https://github.com/alichherawalla/off-grid-mobile-ai) - React Native app for running LLMs, vision models, and Stable Diffusion on-device on iOS and Android without internet access. #opensource
 


### PR DESCRIPTION
Adds a free, no-signup **LLM VRAM calculator** to the **Local LLM Deployment** section, next to RunThisLLM (same category — hardware fit checking).

Enter a model size, quantization (Q4/Q8/FP16) and context length and it returns the VRAM / unified memory needed to run the model locally and which GPUs fit. No account, no paywall.

https://verdictbits.com/reviews/llm-vram-calculator/

Follows the list format `[Name](Link) - Description.`; hosted tool so no #opensource tag (consistent with Msty / LM Studio / RunThisLLM entries). Happy to adjust wording or placement.
