### PR TITLE
Add Model Catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Morpher AI](https://morpher.com/ai) - Morpher AI delivers real-time insights and analysis for any market.
 - [Whimsical AI](https://whimsical.com/ai) - GPT-powered mind mapping, flowcharts, and visual tools for rapid idea development and process organization.
 - [Selfies with Sama](https://selfies-with-sama.vost.ai) - Grab a picture with a real-life billionaire!
+- [Model Catalog](https://openviglet.github.io/model-catalog) - A vendor-neutral, kind-aware catalog of LLM, embedding, rerank and media model ids and capabilities (context window, modalities), published as a free, versioned JSON API.
 
 ## Learning resources
 


### PR DESCRIPTION
Adds **[Model Catalog](https://openviglet.github.io/model-catalog)** to the **Other** section.

Model Catalog is a **vendor-neutral, kind-aware catalog of LLM / embedding / rerank / media model ids** and their capabilities (kind, context window, max output tokens, embedding dimensions, modalities). It's a **free, unauthenticated, CORS-open, versioned JSON API** — no signup:

- `catalog.json` (rolling latest) · `catalog-v1.json` (pinned) · `catalog.schema.json`
- Apache-2.0, zero-dependency; read-only client SDKs for Java, JS/TS and Python.

Disclosure: I maintain this project. Happy to adjust the wording/placement or drop it if it's not a fit — thanks!