### PR TITLE
Add Humanize-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [QuillBot](https://quillbot.com) - AI-powered paraphrasing tool.
 - [Postwise](https://postwise.ai/) - Write tweets, schedule posts and grow your following using AI.
 - [Copysmith](https://copysmith.ai/) - AI content creation solution for Enterprise & eCommerce.
+- [Humanize-Text](https://github.com/lynote-ai/humanize-text) - AI text humanizer with a multilingual rewriting pipeline and step-by-step examples. #opensource
 
 ### ChatGPT extensions
 


### PR DESCRIPTION
Adds `Humanize-Text` to Text > Writing assistants.

Why it may fit the main list:

- open-source AI writing assistant focused on rewriting AI-generated drafts into more natural human writing
- well-documented pipeline with concrete examples and reproducible usage
- actively maintained and currently at 1.5k+ GitHub stars

Repo: https://github.com/lynote-ai/humanize-text
Homepage: https://lynote.ai/ai-humanizer

Disclosure: I am submitting this on behalf of the project author.