### PR TITLE
Add whatbroke to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -149,6 +149,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
+- [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds whatbroke to the Developer tools section of the Discoveries list. It is a CLI that diffs an AI agent's behavior between two runs: tool calls, arguments, cost, latency, and outcome changes, with multi-sample flake detection. MIT licensed, on npm as whatbroke-cli. Submitting to Discoveries since the project is new and does not yet meet the main list criteria. Happy to adjust formatting if needed.