### PR TITLE
Add Echo99 to Speech-to-text discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -243,6 +243,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 ### Speech-to-text
 
 - [Typist](https://iamtypist.dev) - Fast audio transcription service powered by Whisper models hosted on Groq.
+- [Echo99](https://www.echo99.app/) - A private macOS call recorder with on-device transcription and speaker labeling.
 
 ### Music
 - [Boomy](https://boomy.com/) - Create original songs in seconds.


### PR DESCRIPTION
## Summary

Add Echo99 to the Speech-to-text section of the Discoveries list.

Echo99 is a private macOS call recorder with on-device transcription and speaker labeling.

## Why it fits

- uses on-device AI for speech-to-text and speaker labeling
- records microphone and system audio as separate tracks
- works without a meeting bot or account
- keeps recordings and transcripts on the Mac

The Discoveries list is the appropriate destination under the contribution guidelines because Echo99 does not yet meet the Main List's follower threshold.

## Validation

- `git diff --check`
- confirmed the change is one entry at the bottom of Speech-to-text
- confirmed the Echo99 website returns HTTP 200
- checked for an existing Echo99 entry or submission
