### PR TITLE
Add Autopunk Media Skills — AI agents for media professionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [Autopunk Media Skills](https://github.com/ur-grue/autopunk-media-skills) - 394 quality-tested AI skills and 6 multi-step agents for journalists, TV producers, podcasters, and YouTubers. Works with Claude, ChatGPT, and any LLM. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds [Autopunk Media Skills](https://github.com/ur-grue/autopunk-media-skills) to the Autonomous agents section.

**What it is:** An open-source library of 394 quality-tested AI skills and 6 multi-step agents for journalists, TV producers, podcasters, YouTubers, and PR teams.

**Why it fits the agents section:** The six agents (magazine editor, investigative reporter, documentary development, YouTube channel operator, podcast producer, PR crisis response) each chain multiple skills into autonomous workflows — not just single prompts.

**Quality:** Every skill scored on a seven-dimension G-Eval rubric. Library mean: 4.38/5. 4.0/5 minimum to ship as stable.

MIT licensed, 16 stars, actively maintained. Works with Claude, ChatGPT, Cursor, Codex CLI, Gemini CLI.