### PR TITLE
Add VibeKit to Discoveries (Coding Assistants)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -122,6 +122,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - CLI tool that translates natural-language prompts into shell commands and asks for confirmation before execution.
 - [Yume](https://github.com/aofp/yume) - Desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, and plugin system. #opensource
 - [Frontman](https://frontman.sh/) - A browser-based AI coding agent for editing frontend code with live app context. [#opensource](https://github.com/frontman-ai/frontman)
+- [VibeKit](https://vibekit.bot) - Build and run web apps from a phone: every app gets a persistent AI agent that codes it, hosts it on a live domain, and keeps iterating after the first build.
 
 ### Developer tools
 


### PR DESCRIPTION
Adding [VibeKit](https://vibekit.bot) to the Discoveries Coding Assistants section, alongside Bolt.new / Replit Agent / Workshop which it's closest to in spirit.

What it is: a phone-first AI app builder — each app gets its own persistent agent that writes the code, hosts the app on a live domain, and keeps iterating across sessions (it doesn't stop at the first generated prototype). Free tier available; BYOK (Anthropic/OpenAI) supported. Native iOS app on the App Store.

Went with Discoveries rather than the main list since we don't yet clear the 1,000-follower bar in your inclusion criteria. Disclosure: I'm the founder. Format matched to the section (entry at bottom of category, ends with a period).