### PR TITLE
Add Distil to Autonomous agents

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -175,6 +175,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 - [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
+- [Distil](https://distil-cx.fly.dev?ref=awesome-generative-ai) - An AI interviewer that runs user research conversations with your users and returns transcripts instead of survey rows.
 
 ### Custom assistants
 

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -175,7 +175,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 - [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
-- [Distil](https://distil-cx.fly.dev?ref=awesome-generative-ai) - An AI interviewer that runs user research conversations with your users and returns transcripts instead of survey rows.
+- [Distil](https://distil.cx?ref=awesome-generative-ai) - An AI interviewer that runs user research conversations with your users and returns transcripts instead of survey rows.
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds Distil to the Discoveries list under Autonomous agents.

Distil runs user-research interviews as a conversation: you post a question, respondents talk to an AI interviewer that asks its own follow-ups, and you read transcripts rather than survey rows.

Entry follows the existing format and is appended to the bottom of the section.