### PR TITLE
Add AI Visibility Check to discoveries list

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [AI Visibility Check](https://alexander-k-eliot.github.io/ai-visibility-check-free/) - Free, in-browser check for whether ChatGPT, Claude, Perplexity, and other AI assistants can actually read and cite your website; includes llms.txt/robots.txt/JSON-LD generators. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds a free, in-browser tool to the Discoveries list under Developer tools. It runs client-side checks (llms.txt, robots.txt, JSON-LD, sitemap, title/meta) to show whether AI assistants like ChatGPT and Perplexity can actually read a given website, and includes generators for the missing files. No signup, nothing stored.