### PR TITLE
Add cap-evolve to Agents > Autonomous agents (Discoveries)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -176,6 +176,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 - [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
+- [cap-evolve](https://github.com/skillberry-ai/cap-evolve) - Optimize agentic capabilities with agents. Reflective optimizer for AI agent prompts, tool code, MCP tool surfaces, and skill packages; learns from both successful and failed evaluation traces, val-only significance gate with a sealed test split scored once. Adapters for τ²-bench, SWE-bench, SkillsBench. Zero runtime deps. [#opensource](https://github.com/skillberry-ai/cap-evolve)
 
 ### Custom assistants
 


### PR DESCRIPTION
Adding [cap-evolve](https://github.com/skillberry-ai/cap-evolve) to the **Agents → Autonomous agents** section of the Discoveries list.

cap-evolve is an open-source optimizer for agentic capabilities: it uses agents to optimize an agent's prompts, tool code, MCP tool surfaces, and skill packages. It runs an outer loop — evaluate → learn from both successful and failed traces → propose an edit → keep only if it beats a held-out val split by a significance margin → commit. The test split is sealed and scored exactly once, so the final number is honest. Bring your own coding agent as the optimizer (Claude Code, Codex, Gemini CLI, and more).

- Repo: https://github.com/skillberry-ai/cap-evolve
- Docs: https://skillberry-ai.github.io/cap-evolve/
- Adapters for τ²-bench, SWE-bench, SkillsBench; zero runtime deps; Apache-2.0

The project is early-stage (beta, 0.x) which is why I'm targeting the Discoveries list rather than the main list. Entry placed at the bottom of the Autonomous agents section per the contribution guidelines.

Disclosure: I am affiliated with this project.