### PR TITLE
Add Nova to Discoveries > Video

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -227,6 +227,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [Nova](https://novaclipper.com/) - Turns long videos into captioned vertical clips, and generates faceless videos from a script or a Reddit thread.
 
 ### Avatars
 


### PR DESCRIPTION
Adding Nova to the Discoveries list under Video.

Nova does two things: it turns long-form video (podcasts, streams, YouTube
uploads) into captioned vertical clips with AI moment detection and 9:16
reframing, and it generates faceless videos — a script or a Reddit thread
narrated in an AI voice over looping gameplay with word-by-word captions.

Submitting to DISCOVERIES.md rather than the main list, since Nova doesn't meet
the 1,000-follower bar in CONTRIBUTING.md yet.

Format checked against the guidelines: appended to the bottom of the Video
category, `[Name](Link) - Description.` form, ends with a period, no trailing
whitespace.