### PR TITLE
Add FreeLLMAPI to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [FreeLLMAPI](https://freellmapi.co/) - A self-hosted OpenAI-compatible proxy that stacks the free tiers of 28 LLM providers behind a single endpoint. [#opensource](https://github.com/tashfeenahmed/freellmapi)
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [FreeLLMAPI](https://freellmapi.co/) to the bottom of the Developer tools category, per the contribution guidelines.

- Format follows `[ProjectName](Link) - Description.` with the `#opensource` tag (MIT license).
- Meets Main List criterion 1: 17k+ GitHub stars, actively maintained.
- It's a self-hosted OpenAI-compatible proxy that stacks the free tiers of 28 LLM providers behind a single endpoint — sits naturally alongside the existing OpenRouter and Bifrost entries.

Disclosure: I'm the author of the project.
