### PR TITLE
Add StructEval leaderboard

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -101,6 +101,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 - [Price Per Token](https://pricepertoken.com/) - A tool for comparing LLM API pricing, token usage, and model benchmarks.
 - [Rival](https://rival.tips) - Leaderboard ranking 200+ AI models based on blind A/B human preference votes.
+- [StructEval](https://tiger-ai-lab.github.io/StructEval/) - A TMLR benchmark and leaderboard for LLM generation and conversion across 2,035 examples and 18 text and visual structured-output formats. [#opensource](https://github.com/TIGER-AI-Lab/StructEval).
 
 ### Other text generators
 


### PR DESCRIPTION
## Summary

Add StructEval to the Text → Leaderboards section of `DISCOVERIES.md`, following the repository's inclusion guidance for research projects below the main-list follower threshold.

## Why it fits

StructEval is a TMLR benchmark with a public model leaderboard for LLM generation and conversion across 2,035 examples and 18 text and visual structured-output formats. The entry links the official project page and open-source implementation.

## Validation

- followed `CONTRIBUTING.md` and appended to the existing category
- checked the full default tree, history, and all prior suggestions for duplicates
- `git diff --check`
- verified both primary links
- `awesome-lint DISCOVERIES.md` reports the same 34 pre-existing diagnostics before and after this entry

I maintain StructEval and am submitting this entry transparently for maintainer review.

This contribution was prepared with assistance from OpenAI Codex.
