### PR TITLE
Add SenseBench to Discoveries (Leaderboards)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -101,6 +101,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 - [Price Per Token](https://pricepertoken.com/) - A tool for comparing LLM API pricing, token usage, and model benchmarks.
 - [Rival](https://rival.tips) - Leaderboard ranking 200+ AI models based on blind A/B human preference votes.
+- [SenseBench](https://sense-bench.com) - A leaderboard ranking LLMs on English word sense disambiguation over 4,861 lexicographer-reviewed WordNet items, with classic supervised baselines on the same data. [#opensource](https://github.com/GliteTech/sensebench)
 
 ### Other text generators
 


### PR DESCRIPTION
Adds one entry to the bottom of **DISCOVERIES.md → Text → Leaderboards**, after Rival. Targeting Discoveries deliberately — SenseBench doesn't meet the main list's established-following bar, and Discoveries is the right home for it.

```markdown
- [SenseBench](https://sense-bench.com) - A leaderboard ranking LLMs on English word sense disambiguation over 4,861 lexicographer-reviewed WordNet items, with classic supervised baselines on the same data. [#opensource](https://github.com/GliteTech/sensebench)
```

**It produces its own measurements rather than aggregating anyone else's.** It runs the models directly and publishes primary results: 198 verified runs across 63 models so far. Each model is shown a target word in its sentence context together with the candidate WordNet 3.0 senses and must return the index of the correct one.

Two things that may make it worth a slot:

* Every submitted run is re-verified in CI from the stored raw API request and response artifacts, rather than trusted from reported numbers. Results carry bootstrap confidence intervals and paired significance tests.
* Classic supervised WSD systems are scored on identical items for reference, so the LLM numbers sit next to a meaningful floor rather than in isolation.

Code is Apache-2.0 and on PyPI as `sensebench`; the dataset is a lexicographer-reviewed correction layer over the standard academic WSD evaluation set. Links verified live: site, both repos, and the package.