### PR TITLE
Add The Agentic AI Hub under Learning resources

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -283,6 +283,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Gemini by Example](https://geminibyexample.com) - A hands-on introduction to the Gemini API and SDK through annotated code examples. [#opensource](https://github.com/strickvl/geminibyexample)
 - [Rearchitecting LLMs](https://www.manning.com/books/rearchitecting-llms) - A book about optimizing and restructuring LLMs for domain-specific use.
 - [PromptZone](https://promptzone.com/) - Community and publication for prompt engineering, LLM comparisons, and AI-tool workflows.
+- [The Agentic AI Hub](https://daily.dev/agentic-ai-hub/) - A free handbook for software engineers, from LLM foundations to building autonomous agents. Published by daily.dev under CC BY 4.0.
 
 ## More lists
 


### PR DESCRIPTION
Adds The Agentic AI Hub to the Learning resources section of the Discoveries list.

It is a free reference handbook for software engineers: 45 chapters across 7 sections, from LLM foundations through building autonomous agents, with guided reading paths and a 6-level AI adoption ladder. No signup, licensed CC BY 4.0.

Disclosure: I work at daily.dev, which publishes it.

Submitting to Discoveries rather than the main list per CONTRIBUTING.md. Happy to adjust the wording.
