### PR TITLE
Add BopMe to Music

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [AIVA](https://www.aiva.ai/) - AI-based music generation assistant. Choose from 250+ styles.
 - [Suno AI](https://suno.com/) - Anyone can make great music. No instrument needed, just imagination. From your mind to music.
 - [Udio](https://www.udio.com/) - Discover, create, and share music with the world.
+- [BopMe](https://bopme.co) - Personalized funny songs written and sung about a specific person, in 60+ music styles.
 
 ## Other
 


### PR DESCRIPTION
Adds [BopMe](https://bopme.co) to the **Music** section.

```
- [BopMe](https://bopme.co) - Personalized funny songs written and sung about a specific person, in 60+ music styles.
```

**What it is:** you give it a name and a few details about someone, pick a music style, and it writes the lyrics and produces a full song about that person. It sits on the consumer/gifting side of generative music rather than the production side, so it complements the model-and-studio tools already in this section.

Checked against CONTRIBUTING.md:
- Format `[ProjectName](Link) - Description.` with a closing period
- Added to the **bottom** of its category
- Description kept concise
- No trailing whitespace

**On the inclusion criteria:** I want to be straight with you rather than overclaim. BopMe is new and does not yet clear the 1,000-follower bar for the Main List, so the Discoveries list is the honest home for it if you agree. Entirely your call, and no hard feelings if it is not a fit.

Thanks for maintaining the list.