### PR TITLE
Add Shim to Coding / Developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [Shim](https://getshim.tech) - An AI gateway that redacts PII from prompts before they reach model providers and keeps a tamper-evident audit log for EU AI Act evidence.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [Shim](https://getshim.tech) to `DISCOVERIES.md` → Coding → Developer tools.

`- [Shim](https://getshim.tech) - An AI gateway that redacts PII from prompts before they reach model providers and keeps a tamper-evident audit log for EU AI Act evidence.`

Submitted straight to the Discoveries list rather than the main list — Shim doesn't meet the 1,000-follower bar in CONTRIBUTING.md, so this saves you the triage step.

Formatting: `[Name](Link) - Description.`, appended to the bottom of its category, no trailing whitespace. No `#opensource` tag — the gateway is commercial (public docs, free tier).

Disclosure: I work on Shim, so this is a self-submission. Close it without ceremony if it isn't a fit.