### PR TITLE
Add ClawSouls to Custom assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 
 - [Poe](https://poe.com/) - Poe gives access to a variety of bots.
 - [GPT Builder](https://chatgpt.com/gpts/editor) - Assistant for creating GPT-based assistants.
+- [ClawSouls](https://clawsouls.ai/) - Open, vendor-neutral spec and registry for AI agent personas, with a CLI to install personas, verify them with SoulScan, and keep memory portable across models.
 
 ## Image
 


### PR DESCRIPTION
Adds ClawSouls to the Agents → Custom assistants section.

- **[ClawSouls](https://clawsouls.ai/)** — an open, vendor-neutral specification and registry for AI agent personas, with a CLI to install personas, verify them with SoulScan, and keep memory portable across models.
- Repo: https://github.com/clawsouls · Spec: https://clawsouls.ai/spec

Formatting follows CONTRIBUTING.md: single line, factual description ending with a period, added to the bottom of the category.