### PR TITLE
Add Trends MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [Trends MCP](https://github.com/trendsmcp-ai/Trends-MCP) - Live trend data MCP server and REST API across 25+ platforms.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds a listing for [Trends MCP](https://github.com/trendsmcp-ai/Trends-MCP) (https://trendsmcp.ai).

Live trend data MCP server and REST API across 25+ platforms (Google Search, YouTube, TikTok, Reddit, Amazon, Wikipedia, news sentiment, app downloads, npm, Steam, and more).

Public product links only. No secrets or credentials included.