### PR TITLE
Add AI Applyd

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -267,6 +267,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [KeepRule](https://keeprule.com) - Investment-discipline tool with curated principles from 26 investors and AI prompts for scenario analysis.
 - [GEOScore AI](https://geoscoreai.com/) - Free AI search visibility scanner that checks 11 GEO signals for ChatGPT, Perplexity, and Gemini visibility.
 - [DeepDNA](https://deepdna.ai) - AI-powered DNA analysis platform for personalized health, nutrition, and pharmacogenomic insights from consumer genetic data.
+- [AI Applyd](https://aiapplyd.com) - Job-search agent that scores resumes against ATS criteria, then fills and submits applications on the employer's real hiring system and verifies each submission registered.
 
 ## Learning resources
 


### PR DESCRIPTION
Adding AI Applyd to the bottom of the Other section in DISCOVERIES.md.

- [AI Applyd](https://aiapplyd.com) - Job-search agent that scores resumes against ATS criteria, then fills and submits applications on the employer's real hiring system and verifies each submission registered.

Format follows CONTRIBUTING: `[ProjectName](Link) - Description.`, appended to the bottom of its category, description ends with a period, no trailing whitespace.

Disclosure: I build it. Listing under Discoveries rather than the Main List, since it does not meet the 1,000-follower bar.

What is different from the resume tools already listed: it does not stop at "submitted". After the form is filled on the employer's ATS it looks for confirmation the employer's own system produced, and reports the application as pending rather than applied when it cannot find that confirmation. Resume scoring and job-description analysis run on the free tier.