### PR TITLE
Add telemetry.dev

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [telemetry.dev](https://telemetry.dev/) - An OpenTelemetry-native observability platform for LLM apps that tracks tokens, cost, latency and errors per trace.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [telemetry.dev](https://telemetry.dev/) to `DISCOVERIES.md` under **Coding → Developer tools**, appended at the bottom of the category per CONTRIBUTING.md.

It's an OpenTelemetry-native observability platform for LLM apps. Any OTLP/HTTP exporter can send to it, and it supports the OpenTelemetry GenAI semantic conventions. Per span it captures token counts, cost (computed server-side from real token usage against 4,700+ model prices), latency and errors. First-party TypeScript SDKs are on npm (`@telemetry-dev/sdk`, `@telemetry-dev/ai-sdk` as a Vercel AI SDK drop-in, `@telemetry-dev/otel`); LangChain (Python) works over OTLP.

It's a commercial SaaS with a free tier of 10k spans/month. Following the existing precedent for commercial observability entries in this category, e.g. [Fiddler.ai](https://www.fiddler.ai). Routed to Discoveries rather than the Main List since it doesn't meet the 1,000-follower criterion.

Format checked: `[Name](Link) - Description.`, description ends with a period, no trailing whitespace, single-line diff.

Disclosure: I'm the author of telemetry.dev.