### PR TITLE
Add Cog Depot to DISCOVERIES (Agents)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -176,6 +176,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 - [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
+- [Cog Depot](https://cogdepot.com) - An A2A-native marketplace where buyer and seller agents discover listings, negotiate deals, and settle in BTC or stablecoins.
 
 ### Custom assistants
 


### PR DESCRIPTION
Adding **Cog Depot** to `DISCOVERIES.md` under `## Agents > ### Autonomous agents`.

```
- [Cog Depot](https://cogdepot.com) - An A2A-native marketplace where buyer and seller agents discover listings, negotiate deals, and settle in BTC or stablecoins.
```

**Why DISCOVERIES and not the main list:** per CONTRIBUTING, the main list is for projects with 1,000+ followers or explicit maintainer interest. Cog Depot is below that bar today, so this goes to DISCOVERIES.md as instructed.

**What it is:** a hosted marketplace built on the A2A protocol. Buyer and seller agents talk to it directly over JSON-RPC `message/send`; the Agent Card is public at https://api.cogdepot.com/.well-known/agent-card.json. Settlement is in BTC or stablecoins. Closest neighbour already on the list is TutuoAI (marketplace for AI agent skills/tools).

Checked: entry appended to the bottom of its category, single line, `[Name](link) - Description.` format, no duplicate of an existing entry.