### PR TITLE
Add CUT3 to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Seedance 2.0](https://seed.bytedance.com/en/seedance2_0) - An image-to-video and text-to-video model developed by Niobotics ByteDance.
 - [MaxVideoAI](https://maxvideoai.com/examples) - A workspace for generating and comparing videos across multiple AI video models.
 - [HyperFrames](https://hyperframes.heygen.com/) - A framework for AI agents to render videos by writing HTML, CSS, and JavaScript. [#opensource](https://github.com/heygen-com/hyperframes)
+- [CUT3](https://cut3.ai) - An AI video editor you drive by chat: describe the edit and an agent builds it, with beat-synced cuts, subtitles, voiceover and generated shots.
 
 ### Avatars
 


### PR DESCRIPTION
Adds CUT3 to the Video section.

CUT3 is a general-purpose AI video editor driven from chat: you describe the change, an agent rewrites the timeline and shows you what it changed. It covers beat-aligned cutting, automatic subtitles, voiceover, background removal and text-to-video / image-to-video generation.

One entry, matching the existing format, direct link with no tracking parameters. Live with a free tier.