### PR TITLE
Add Unified AI System to Developer tools discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [Unified AI System](https://github.com/happy520ai/unified-ai-system) - An open, local-first AI gateway for multi-model routing, governed agents, knowledge, tools, and human approvals, with a credential-free terminal demo. #opensource
 
 ### Playgrounds
 

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,7 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
-- [Unified AI System](https://github.com/happy520ai/unified-ai-system) - An open, local-first AI gateway for multi-model routing, governed agents, knowledge, tools, and human approvals, with a credential-free terminal demo. #opensource
+- [Unified AI System](https://github.com/happy520ai/unified-ai-system) - An open, local-first AI gateway with provider-free prompt enhancement and nine MCP tools for Codex, Cursor, and Cline; the Docker demo needs no account or API key. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
## Summary

- add Unified AI System to `Discoveries > Coding > Developer tools`
- describe the current provider-free prompt enhancement and nine-tool MCP surface for Codex, Cursor, and Cline
- keep the claim scoped to a credential-free public Docker path

## Why Discoveries

This is a transparent self-submission from the project maintainer. The repository is an early public preview, so I am intentionally proposing the Discoveries list rather than claiming the adoption threshold required for the Main List.

## Quick evaluation

```bash
docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.0 pnpm gateway demo
```

## Verification

- Public repository: https://github.com/happy520ai/unified-ai-system
- License: Apache-2.0
- Current release: https://github.com/happy520ai/unified-ai-system/releases/tag/v0.4.0
- Official MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.0
- Current CI and credential-free public-clone verification: https://github.com/happy520ai/unified-ai-system/actions/runs/30755010041

The change is one factual entry in the existing format and remains at the bottom of the category, as requested by the contribution guide. It does not claim production readiness, L5 autonomy, or AGI.

Disclosure: I maintain the submitted project.