### PR TITLE
Add Swobu to Developer tools discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [Swobu](https://github.com/swobuforge/swobu) - A local AI gateway (single Go binary) that terminates OpenAI, Anthropic Messages, and remote-MCP client traffic, routing across providers, regions, accounts, and local models with failover. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds **Swobu** to `DISCOVERIES.md` → `## Coding` → `### Developer tools`, appended to the bottom of the category per the contribution rules.

**Swobu** — https://github.com/swobuforge/swobu

A local AI gateway (single Go binary, AGPL-3.0) that terminates OpenAI, Anthropic Messages, and remote-MCP client traffic, routing across providers, regions, accounts, and local models with failover. Actively maintained (last push 2026-07-30), release v1.0.0-rc.2. It sits naturally next to the existing gateway entries in this section (GPTRouter, EvoLink).

Both the repo link and project homepage resolve (HTTP 200). Entry follows the repo-link + bare ` #opensource` convention used by the section's other open-source entries, ends with a period, and has no trailing whitespace. Placed in Discoveries rather than the main README since the project is still early-stage (it does not yet meet the main list's general-interest/followers bar).

Disclosure: I maintain Swobu. Single-purpose diff.