### PR TITLE
Add AIGCDataHub to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -294,5 +294,6 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Awesome AI Software Development Agents](https://github.com/flatlogic/awesome-ai-software-development-agents) - Curated list of AI agents designed for software development tasks.
 - [MODELDROP](https://modeldrop.fyi/) - A community tracker for new generative media AI model releases.
 - [MyVibe](https://www.myvibe.so) - A feed for discovering and sharing AI-created web apps, demos, and interactive projects.
+- [AIGCDataHub](https://github.com/TobinZuo/AIGCDataHub) - Source-cited catalog of generative-media models, training datasets, licenses, access conditions, and model-dataset lineage. [#opensource](https://github.com/TobinZuo/AIGCDataHub).
 
 ### Lists on ChatGPT


### PR DESCRIPTION
Adds AIGCDataHub to `DISCOVERIES.md` → `More lists`.

AIGCDataHub is an open, machine-readable catalog that links generative-media models to disclosed training, fine-tuning, preference, and evaluation datasets. It records licenses, access conditions, primary-source evidence, and model–dataset lineage.

This targets Discoveries because the project is new and does not meet the Main List’s 1,000-follower threshold.

Disclosure: I maintain AIGCDataHub.