### PR TITLE
Add Podiom to Discoveries: Developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [Podiom](https://github.com/Podiom/Podiom) - Local-first orchestration layer for Claude Code and Codex CLI agents: durable named agents, sessions that survive provider switches, a shared project ledger, and built-in scheduling, in a single Go binary. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [Podiom](https://github.com/Podiom/Podiom) to DISCOVERIES.md under Coding > Developer tools.

Podiom is a new (1 month old), small (1 star) local-first orchestration layer for Claude Code and Codex CLI agents: durable named agents, sessions that survive provider/profile switches, a shared project ledger, and built-in scheduling, in a single Go binary with an embedded web UI. MIT licensed.

Submitting to Discoveries rather than the main README per CONTRIBUTING.md, since the project doesn't yet meet the 1,000+ follower bar for the main list. One entry, appended at the end of the Developer tools subsection, `#opensource` tag matching sibling entries.