### PR TITLE
Add AGINE Academy to Learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAI Prompt Engineering Guide](https://platform.openai.com/docs/guides/prompt-engineering) - Strategies and tactics for getting better results from large language models.
 - [PromptPerfect](https://promptperfect.jina.ai/) - Tool for prompt engineering.
 - [Anthropic courses](https://github.com/anthropics/courses) - Anthropic's educational courses.
+- [AGINE Academy](https://academy.agineai.com/en) - A game-based academy for learning Claude by doing: hands-on missions inside the real Claude apps, with a free starting block.
 - [Build a Large Language Model (From Scratch)](https://www.manning.com/books/build-a-large-language-model-from-scratch) - A guide to building your own working LLM, by Sebastian Raschka.
 - [Prompt Engineering for Vision Models](https://www.deeplearning.ai/short-courses/prompt-engineering-for-vision-models/) - A free DeepLearning.AI short course on how to prompt computer vision models with natural language, bounding boxes, segmentation masks, coordinate points, and other images.
 - [Build a Reasoning Model (From Scratch)](https://www.manning.com/books/build-a-reasoning-model-from-scratch) - A guide to building a working reasoning model from the ground up, by Sebastian Raschka.


### PR DESCRIPTION
Adds AGINE Academy to Learning resources, next to Anthropic courses.

Disclosure: I help build this product. It is a game-based academy for learning Claude through hands-on missions inside the real Claude apps. The 4-lesson starting block is free with no sign-up; the full program is paid. English and Russian. Independent, not affiliated with Anthropic.

Happy to adjust wording or placement.