### PR TITLE
Add VideoGen to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Google Flow](https://labs.google/fx/tools/flow) - An AI filmmaking tool from Google, powered by Veo.
 - [Seedance 2.0](https://seed.bytedance.com/en/seedance2_0) - An image-to-video and text-to-video model developed by Niobotics ByteDance.
 - [MaxVideoAI](https://maxvideoai.com/examples) - A workspace for generating and comparing videos across multiple AI video models.
+- [VideoGen](https://videogen.io/ai-video-generator) - Turn a prompt, script, or article into a complete video with AI voiceover, subtitles, and b-roll.
 - [HyperFrames](https://hyperframes.heygen.com/) - A framework for AI agents to render videos by writing HTML, CSS, and JavaScript. [#opensource](https://github.com/heygen-com/hyperframes)
 
 ### Avatars


### PR DESCRIPTION
Adds VideoGen (https://videogen.io/ai-video-generator) to the Video section.

VideoGen is a Y Combinator-backed AI video generator that turns a prompt, script, or article into a complete multi-scene video with AI voiceover, timed subtitles, and b-roll, generating footage with Sora, Veo, Kling, and other leading models. Free plan available; paid plans from $12/mo. Live since 2022, not a duplicate of any existing entry, and the link is not an affiliate link.
