### PR TITLE
Add Keygate to leaderboard discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -101,6 +101,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 - [Price Per Token](https://pricepertoken.com/) - A tool for comparing LLM API pricing, token usage, and model benchmarks.
 - [Rival](https://rival.tips) - Leaderboard ranking 200+ AI models based on blind A/B human preference votes.
+- [Keygate](https://keygate.ai/) - AI model evaluation platform for text, image, video, and speech models, with rankings, pricing, speed, and side-by-side comparisons.
 
 ### Other text generators
 


### PR DESCRIPTION
Adds Keygate to `DISCOVERIES.md` under **Text → Leaderboards**.

Keygate is an actively maintained AI model evaluation platform covering text, image, video, and speech models. Its public site provides rankings, pricing, speed, side-by-side comparisons, and a documented evaluation methodology.

This change adds one concise entry in the official Discoveries format. It does not reproduce an article, dataset, chart, or table.

Disclosure: I maintain Keygate.