### PR TITLE
Add commitpreflight

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [commitpreflight](https://github.com/swarmbrr/commitpreflight) - A CLI and pre-commit hook that catches malformed commit messages from AI coding agents, with rules derived from real agent failures. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds commitpreflight to the developer tools section of DISCOVERIES.md.

commitpreflight is an open-source CLI and pre-commit hook that catches malformed commit messages produced by AI coding agents (subject overshoot, missing type, trailing punctuation) before they land. Rules were derived from real agent commit failures rather than style preference.

Entry follows the existing format and is placed alphabetically-neutral, directly after the adjacent agent-tooling entries.