### PR TITLE
Add Dracon Omni to Developer tools discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [Dracon Omni](https://dracon.uk/ai-hub) - BYOK AI workspace: encrypted key manager for 42 providers, router config builder for LiteLLM and opencode, and a ranked catalog of free API tiers. Flat subscription, no credits, no markup.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [Dracon Omni](https://dracon.uk/ai-hub) to the bottom of the Developer tools section in DISCOVERIES.md, per the contribution guidelines.

**What it is:** a BYOK (bring-your-own-key) AI workspace: an encrypted key manager covering 42 AI providers, a router config builder that exports fallback chains as LiteLLM YAML / opencode JSON, and a ranked catalog of free API tiers across those providers. Flat subscription for the tools; usage is paid directly to providers at list price (no credits, no markup, browser-direct calls).

**Why Developer tools:** the router config builder and key manager are developer-facing infrastructure in the same category as the existing GPTRouter and AI/ML API entries.

Per the inclusion criteria, this belongs in Discoveries rather than the Main List (new project, under the follower threshold).