### PR TITLE
Add Pipe2.ai to Video discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -227,6 +227,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [Pipe2.ai](https://pipe2.ai/) - Multi-step pipelines for video, image, audio, and text generation, runnable from the web, a CLI, SDKs, or an MCP server.
 
 ### Avatars
 


### PR DESCRIPTION
Adds Pipe2.ai to the Video section of the Discoveries list.

Pipe2.ai runs multi-step generative pipelines for video, image, audio and text — each takes a small input and returns a finished asset rather than a single model call. It can be driven from the web app, a command-line tool, SDKs, or an MCP server.

Submitting to Discoveries rather than the Main List: it doesn't meet the 1,000-follower bar, and per CONTRIBUTING that's what Discoveries is for.

Format checked against the guidelines — `[ProjectName](Link) - Description.`, appended to the bottom of its category, no trailing whitespace. One line changed.