### PR TITLE
Add HokAI to Discoveries list

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -294,5 +294,6 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Awesome AI Software Development Agents](https://github.com/flatlogic/awesome-ai-software-development-agents) - Curated list of AI agents designed for software development tasks.
 - [MODELDROP](https://modeldrop.fyi/) - A community tracker for new generative media AI model releases.
 - [MyVibe](https://www.myvibe.so) - A feed for discovering and sharing AI-created web apps, demos, and interactive projects.
+- [HokAI](https://hokai.io) - Directory for discovering and comparing AI tools, agents, models, and MCP skills.
 
 ### Lists on ChatGPT


### PR DESCRIPTION
Adding HokAI (https://hokai.io), a directory for discovering and comparing AI tools, agents, models, and MCP skills, to the Discoveries list per the criteria in CONTRIBUTING.md.

- Added to the bottom of the "More lists" category in DISCOVERIES.md
- Format matches surrounding entries: `[ProjectName](Link) - Description.`