### PR TITLE
docs: add Agent Console

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -176,6 +176,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 - [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
+- [Agent Console](https://github.com/Perseon-Lab/agent-console) - Open-source browser mission control for Hermes-powered AI agents, with chat, session visibility, cron jobs, skills, voice controls, and read-only mission runs. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds Agent Console to the Discoveries list under Agents / Autonomous agents.

Agent Console is an open-source browser mission control surface for Hermes-powered AI agents. It provides chat, session visibility, cron jobs, skills, voice controls, and read-only mission runs from one local web UI.

I am submitting this to `DISCOVERIES.md` rather than the main list because the project is new and does not yet meet the main-list follower threshold.

Validation:
- Reviewed the Markdown diff locally
- Ran `git diff --check`
