### PR TITLE
Add Nutilz Background Remover to Image > Services (Discoveries)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -203,6 +203,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [deAPI.ai](https://deapi.ai/) - A unified inference API to open-source AI models for text-to-image, text-to-speech, transcription, video generation, and more, using a decentralized GPU cloud.
 - [MyPicNow](https://www.mypicnow.com) - An AI headshot generator for creating professional profile photos from uploaded selfies.
 - [PhotoMentor](https://photomentor.pro) - An AI tool for analyzing photos and providing composition and lighting feedback.
+- [Nutilz Background Remover](https://nutilz.com/background-remover) - Free AI background remover that runs entirely in the browser via WASM, no upload or sign-up required, outputs a transparent PNG.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds Nutilz Background Remover (https://nutilz.com/background-remover), a free AI background removal tool that runs entirely client-side in the browser using WASM — no upload to a server, no sign-up, outputs a transparent PNG. Added to the Discoveries list per the contribution guidelines since this is a newer tool. Placed in Image > Services alongside similar tools like Picwish.