### PR TITLE
Add AI Economics Tools to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,7 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
-- [AI Economics Tools](https://github.com/pich/ai-economics-tools) - 12 self-contained calculators for AI cost, energy and agent verification by Michał Piszczek, with a keyless JSON API and an MCP server. #opensource
+- [AI Economics Tools](https://github.com/pich/ai-economics-tools) - 12 self-contained calculators for AI cost, energy and agent verification by Michał Piszczek ([piszczek.pl/tools](https://piszczek.pl/tools)), with a keyless JSON API and an MCP server. #opensource
 
 ### Playgrounds
 

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,7 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
-- [AI Economics Tools](https://github.com/pich/ai-economics-tools) - 12 self-contained calculators for AI cost, energy and agent verification, with a keyless JSON API and an MCP server. #opensource
+- [AI Economics Tools](https://github.com/pich/ai-economics-tools) - 12 self-contained calculators for AI cost, energy and agent verification by Michał Piszczek, with a keyless JSON API and an MCP server. #opensource
 
 ### Playgrounds
 

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [AI Economics Tools](https://github.com/pich/ai-economics-tools) - 12 self-contained calculators for AI cost, energy and agent verification, with a keyless JSON API and an MCP server. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds **[AI Economics Tools](https://github.com/pich/ai-economics-tools)** to `DISCOVERIES.md` → Coding → Developer tools (appended to the bottom of the category, per CONTRIBUTING).

12 self-contained HTML calculators (MIT, no build step, no tracking) for the numbers behind AI budgets: token cost across vendors, context-window sizing, agent-hour cost, model-routing savings, LLM energy & CO₂, joules per verified task, token burn, humanoid energy budgets, Proof-Adjusted Autonomy, revocation exposure, verification bottleneck, proof debt.

Each also has a keyless, CORS-open JSON API (https://piszczek.pl/tools/api, OpenAPI 3.1 at /openapi.json) and an MCP server (`npx -y @michalpiszczek/ai-economics-mcp`, official MCP Registry `pl.piszczek/ai-economics`), so AI assistants can compute the answer rather than estimate it.

Live: https://piszczek.pl/tools

Disclosure: PR prepared by an AI agent on behalf of the author (Michał Piszczek).