### PR TITLE
Add AI Dictation to speech-to-text discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -244,6 +244,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 - [Typist](https://iamtypist.dev) - Fast audio transcription service powered by Whisper models hosted on Groq.
 - [Echo99](https://www.echo99.app/) - A private macOS call recorder with on-device transcription and speaker labeling.
+- [AI Dictation](https://aidictation.com/) - Cross-platform voice-to-text app with offline recognition on supported devices, optional cleanup, and [MIT-licensed native client source](https://github.com/writingmate/aidictation).
 
 ### Music
 - [Boomy](https://boomy.com/) - Create original songs in seconds.


### PR DESCRIPTION
## Summary

Add AI Dictation to the bottom of **Audio → Speech-to-text** in `DISCOVERIES.md`.

The Discoveries list is the appropriate path because the project does not meet the Main List's 1,000-follower threshold.

## Validation

- Followed the repository's required `[ProjectName](Link) - Description.` format.
- Verified the product description against the current public repository, MIT license, and release.
- Confirmed both entry links return HTTP 200.
- Searched the list plus open and closed pull requests, issues, and their comments for an existing AI Dictation, `aidictation`, Writingmate, or WhisperMate submission; no duplicate was found.
- Ran `git diff --check` successfully.

## Disclosure

I am affiliated with AI Dictation. This contribution was researched and prepared with AI assistance.
