### PR TITLE
Add Faceless Reels to Video discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -227,6 +227,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [Faceless Reels](https://facelessreels.video/) - Faceless video generator that turns a topic into a voiced, captioned vertical video for TikTok, Reels and Shorts.
 
 ### Avatars
 


### PR DESCRIPTION
Adds [Faceless Reels](https://facelessreels.video/) to the Video section of the Discoveries list.

Faceless Reels turns one topic into a finished vertical video: it writes the hook and script, generates the AI voiceover, captions, visuals and background music, then renders a 9:16 video for TikTok, Instagram Reels and YouTube Shorts. Workflows include storytelling, doodle explainer, stickman animation and open-source project shorts. Freemium (free credits on signup).

Disclosure: I am part of the team building this product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)