### PR TITLE
Add Libre WebUI to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -156,6 +156,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 ### Local LLM Deployment
 
 - [Minima](https://github.com/dmayboroda/minima) - On-premises RAG with configurable Docker containers. #opensource
+- [Libre WebUI](https://librewebui.org) - Self-hosted, local-first AI workspace with chat, RAG over your own documents, artifacts, and sandboxed workspaces for model-driven work. [#opensource](https://github.com/libre-webui/libre-webui)
 
 ## Agents
 


### PR DESCRIPTION
Adds [Libre WebUI](https://librewebui.org) under Text → Local LLM Deployment in the Discoveries list.

Submitting to Discoveries rather than the Main List: the project is at 58 GitHub stars, so it does not yet meet the 1,000-follower criterion in CONTRIBUTING.md.

<img width="1624" height="1012" alt="screenshot" src="https://github.com/user-attachments/assets/a40126ef-2167-4dcc-8cc2-1574af24b0c5" />

Libre WebUI is a self-hosted, local-first AI workspace — chat through Ollama or any provider you connect, RAG over your own documents, artifacts, and isolated sandboxed workspaces where a model can build and run things. Apache-2.0, no CLA, no telemetry. Actively maintained (v0.18.0), documented at https://docs.librewebui.org.

Formatting checked against the guidelines: `[ProjectName](Link) - Description.`, appended to the bottom of its category, no trailing whitespace.