### PR TITLE
Add Soup to Discoveries - Developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [Soup](https://github.com/MakazhanAlpamys/Soup) - One-config CLI to fine-tune and post-train LLMs, including an 8B model on a 4 GB laptop GPU. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Soup is a CLI that runs LLM post-training from a single YAML config: SFT, DPO, GRPO, KTO, ORPO, plus evaluation gating and GGUF export. Apache-2.0, on PyPI as `soup-cli`.

Unlike the other fine-tuning tools nearby, it does not require the base model to fit in VRAM: layer streaming keeps the frozen base in host RAM and streams it into pre-allocated VRAM buffers one decoder layer at a time, so peak VRAM is bounded by a single layer. Measured on an RTX 3050 4 GB laptop GPU, Llama-3.1-8B runs at 119.6 tok/s in 3.32 GB peak.

Submitting to Discoveries rather than the Main List, since the project is at ~190 stars and does not meet the 1,000-follower criterion. Method and raw numbers behind the figure above, including bit-exactness checks against an equivalent resident run, are in https://github.com/MakazhanAlpamys/Soup/tree/main/benchmarks.