### PR TITLE
Add stillworks to Discoveries - More lists

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -295,5 +295,6 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Awesome AI Software Development Agents](https://github.com/flatlogic/awesome-ai-software-development-agents) - Curated list of AI agents designed for software development tasks.
 - [MODELDROP](https://modeldrop.fyi/) - A community tracker for new generative media AI model releases.
 - [MyVibe](https://www.myvibe.so) - A feed for discovering and sharing AI-created web apps, demos, and interactive projects.
+- [stillworks](https://stillworks.supercapybara.com/) - Directories list. We check. A live-probed list of free LLM API endpoints where every row is a real chat completion, failures included. [#opensource](https://github.com/bon5co/stillworks)
 
 ### Lists on ChatGPT


### PR DESCRIPTION
Adds one entry to **DISCOVERIES.md → More lists**.

```
- [stillworks](https://stillworks.supercapybara.com/) - Directories list. We check. A live-probed list of free LLM API endpoints where every row is a real chat completion, failures included. [#opensource](https://github.com/bon5co/stillworks)
```

Submitted to the Discoveries list rather than the main list: stillworks is new and does not meet the 1,000
followers criterion in CONTRIBUTING.md.

**What it is:** a registry of LLM endpoints where every row was produced by a real chat completion sent on a
schedule, not by reading a provider's documentation, and the failures are published next to the successes. 19
endpoints currently answer with no `Authorization` header at all; another 46 are free-tier-with-key, kept in
the same table but labelled. `GET /api/llm/up` returns them ranked, so `models[0]` is the pick and the rest are
fallbacks. Capability flags (`tools`, `json_schema`, `json_object`, `vision`) are listed as `proved` only when
a real call demonstrated them; provider claims that could not be reproduced sit in `claimed_unproved`.

**What it does not claim:** keyless quotas are commonly per-IP, so an endpoint verified from the service's
address can still refuse yours; rows probed with the project's own free-tier key prove only that the endpoint
answered that account. Both limits are stated on the page and in the API response.

MIT licensed, source at https://github.com/bon5co/stillworks

Disclosure: I work on stillworks — this is a self-submission, not a third-party recommendation.
