### PR TITLE
Add BitFun to Coding Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Lovable](https://lovable.dev) - Conversational full-stack app generation, turning ideas into deployable code.
 - [aider](https://aider.chat/) - AI pair programming in your terminal, supporting multiple LLM providers. [#opensource](https://github.com/paul-gauthier/aider)
 - [Kilo](https://kilo.ai/) - Open-source AI coding assistant for VS Code, JetBrains, and the CLI. [#opensource](https://github.com/Kilo-Org/kilocode)
+- [BitFun](https://github.com/GCWing/BitFun) - Open-source AI coding agent with a Rust runtime, desktop and terminal interfaces, and self-hosted cross-device access. [#opensource](https://github.com/GCWing/BitFun)
 
 ### Developer tools
 


### PR DESCRIPTION
## Summary

- Adds [BitFun](https://github.com/GCWing/BitFun) to Main List → Coding → Coding Assistants.
- Keeps the entry to one neutral, directory-style line.

## Inclusion criteria

I help maintain BitFun. The repository currently has 1,486 GitHub stars, satisfying the Main List's 1,000-follower threshold. It is actively maintained; [v0.2.16](https://github.com/GCWing/BitFun/releases/tag/v0.2.16) was released on August 6, 2026, and the project is documented in its README.

Core BitFun code is MIT-licensed; bundled third-party content retains its original licenses.