### PR TITLE
Add Lumora Storybooks to Discoveries > Other

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -268,6 +268,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [KeepRule](https://keeprule.com) - Investment-discipline tool with curated principles from 26 investors and AI prompts for scenario analysis.
 - [GEOScore AI](https://geoscoreai.com/) - Free AI search visibility scanner that checks 11 GEO signals for ChatGPT, Perplexity, and Gemini visibility.
 - [DeepDNA](https://deepdna.ai) - AI-powered DNA analysis platform for personalized health, nutrition, and pharmacogenomic insights from consumer genetic data.
+- [Lumora Storybooks](https://lumora.kids) - Generates an illustrated children's picture book from one photo, keeping the child's likeness consistent across pages, in ten languages.
 
 ## Learning resources
 


### PR DESCRIPTION
Adding [Lumora Storybooks](https://lumora.kids) to `DISCOVERIES.md` under **Other**.

Per CONTRIBUTING.md, the Main List asks for at least 1,000 followers, which we don't meet — so this goes to the Discoveries list, which the guidelines explicitly invite projects to submit through a pull request.

**What it is:** you upload one photo of a child and it generates an illustrated picture book in which that child is the hero, keeping their likeness consistent across every page. Text and illustrations are both generated. It's live and usable now — the first book is free with no card required.

Placed in **Other** rather than Text or Image because it produces both together. Added at the bottom of the category, as the contributing guide asks. One line, one category, description ends with a period and carries no trailing whitespace.

Happy to reword or move it if you'd prefer a different section.