### PR TITLE
Add intentic to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -122,6 +122,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - CLI tool that translates natural-language prompts into shell commands and asks for confirmation before execution.
 - [Yume](https://github.com/aofp/yume) - Desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, and plugin system. #opensource
 - [Frontman](https://frontman.sh/) - A browser-based AI coding agent for editing frontend code with live app context. [#opensource](https://github.com/frontman-ai/frontman)
+- [intentic](https://github.com/intentic/intentic) - Self-hosted workspace for running coding agents (Claude Code, Codex, OpenCode, Gemini CLI) in parallel, each in its own container and git worktree on hardware you own, reachable from any browser or phone, with every change reviewed as a diff before it lands. #opensource
 
 ### Developer tools
 

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -123,6 +123,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Yume](https://github.com/aofp/yume) - Desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, and plugin system. #opensource
 - [Frontman](https://frontman.sh/) - A browser-based AI coding agent for editing frontend code with live app context. [#opensource](https://github.com/frontman-ai/frontman)
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants, auto-capturing decisions, patterns, and context from Claude Code, Cursor, and Cline sessions. #opensource
+- [intentic](https://github.com/intentic/intentic) - Self-hosted workspace that runs Claude Code, Codex, OpenCode and Gemini CLI in parallel, each in its own container and git worktree, reviewed as diffs. #opensource
 
 ### Developer tools
 


### PR DESCRIPTION
Adds **intentic** to the Discoveries list, under *Coding → Coding Assistants*.

Per the contribution guidelines, the project does not yet meet the main list's 1,000-follower bar, so this
targets `DISCOVERIES.md`.

It is a self-hosted workspace for running several coding agents in parallel on hardware the developer owns.
Each agent gets its own container and git worktree, runs continue when the browser closes, any browser or a
phone reopens onto the same fleet, and changes reach the repository only through a per-file, per-hunk diff
review. The sandbox image is an editable Dockerfile the user approves.

Open source (MIT, TypeScript), free, and it runs on the user's own model subscriptions.

Disclosure: I maintain intentic.
