### PR TITLE
Add OpenShorts to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Seedance 2.0](https://seed.bytedance.com/en/seedance2_0) - An image-to-video and text-to-video model developed by Niobotics ByteDance.
 - [MaxVideoAI](https://maxvideoai.com/examples) - A workspace for generating and comparing videos across multiple AI video models.
 - [HyperFrames](https://hyperframes.heygen.com/) - A framework for AI agents to render videos by writing HTML, CSS, and JavaScript. [#opensource](https://github.com/heygen-com/hyperframes)
+- [OpenShorts](https://www.openshorts.app/) - Turn long videos into viral 9:16 shorts with AI moment detection, face tracking, animated subtitles and dubbing. [#opensource](https://github.com/mutonby/openshorts)
 
 ### Avatars
 


### PR DESCRIPTION
Adds **OpenShorts** to the bottom of the `## Video` category.

```md
- [OpenShorts](https://www.openshorts.app/) - Turn long videos into viral 9:16 shorts with AI moment detection, face tracking, animated subtitles and dubbing. [#opensource](https://github.com/mutonby/openshorts)
```

**Inclusion criteria (Main List):** criterion 1 — high general interest / significant followers. The repo [mutonby/openshorts](https://github.com/mutonby/openshorts) has 2.9k+ stars and 800+ forks, well above the 1,000 threshold.

**Quality standards:**
- *Widely used* — 2.9k+ stars, 800+ forks, hosted service at openshorts.app.
- *Actively maintained* — commits within the last few days; issues are being addressed.
- *Well-documented* — full README with Docker Compose setup, `.env.example`, REST API + MCP docs, and a video walkthrough.

**Formatting checklist:**
- [x] `[ProjectName](Link) - Description.` format
- [x] Added to the bottom of its category
- [x] Description is concise and ends with a period
- [x] `[#opensource]` tag pointing at the MIT-licensed repo
- [x] No trailing whitespace