### PR TITLE
Add Vivideo to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Seedance 2.0](https://seed.bytedance.com/en/seedance2_0) - An image-to-video and text-to-video model developed by Niobotics ByteDance.
 - [MaxVideoAI](https://maxvideoai.com/examples) - A workspace for generating and comparing videos across multiple AI video models.
 - [HyperFrames](https://hyperframes.heygen.com/) - A framework for AI agents to render videos by writing HTML, CSS, and JavaScript. [#opensource](https://github.com/heygen-com/hyperframes)
+- [Vivideo](https://vivideo.ai) - Generate short videos from text prompts or images with synced audio across multiple AI models.
 
 ### Avatars
 


### PR DESCRIPTION
Adds [Vivideo](https://vivideo.ai) to the **Video** section.

Vivideo is an AI video generation platform that turns text prompts or images into short videos with synced audio, offering multiple underlying models. Fits alongside the other text-to-video / image-to-video tools already listed (Runway, Pika, Luma, HeyGen, etc.).

Format follows the guidelines: `[ProjectName](Link) - Description.`, appended to the bottom of the category.

Made with [Cursor](https://cursor.com)