### PR TITLE
Add Zephex under Coding Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Lovable](https://lovable.dev) - Conversational full-stack app generation, turning ideas into deployable code.
 - [aider](https://aider.chat/) - AI pair programming in your terminal, supporting multiple LLM providers. [#opensource](https://github.com/paul-gauthier/aider)
 - [Kilo](https://kilo.ai/) - Open-source AI coding assistant for VS Code, JetBrains, and the CLI. [#opensource](https://github.com/Kilo-Org/kilocode)
+- [Zephex](https://zephex.dev) - Hosted MCP tools that ground coding agents in your live repository (context, search, package safety, tests). Works with Cursor, Claude Code, Codex. Free tier.
 
 ### Developer tools
 


### PR DESCRIPTION
Adds a short Zephex listing.

**What:** Hosted MCP that grounds AI agents in your live repo (context, search, package safety, tests).
**Works with:** Cursor, Claude Code, Codex, OpenCode, VS Code — plus CLI & web terminal.
**Links:** https://zephex.dev/mcp · https://github.com/zephexMCP/zephex-MCPs
**Note:** Complements Context7 (library docs) and GitHub MCP (PRs) — not a docs-only server.