### PR TITLE
Add ThoughtDAG to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -45,6 +45,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 ### Custom interfaces
 
 - [Atlas UI 3](https://github.com/sandialabs/atlas-ui-3) - Full-stack LLM chat interface with MCP tool integration, multi-provider support, RAG, and agentic workflows. #opensource
+- [ThoughtDAG](https://github.com/chenxiachan/thoughtdag) - A local-first visual LLM workspace where graph edges determine which conversation and document nodes enter the next model request. #opensource
 
 ### Search engines
 


### PR DESCRIPTION
## Summary

Add ThoughtDAG to **Discoveries → Text → Custom interfaces**.

ThoughtDAG is an actively maintained, MIT-licensed visual LLM workspace. Graph edges determine which upstream conversation and document nodes enter the next model request, making context visible and editable.

The project is being submitted to Discoveries because it is young and does not yet meet the main list's follower threshold.

Disclosure: I maintain ThoughtDAG.