### PR TITLE
Add 365Skill to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [365Skill](https://github.com/laojin1900/365Skill) - A production-tested, bilingual (EN/zh-CN) library of reusable Agent Skills from a cross-border AI team: skill discovery scanner, risk-graded five-step dev workflow, Gmail/Calendar/Drive ops, Shopify theme delivery, and weekly digest. #opensource
+
 
 ### Custom assistants
 


### PR DESCRIPTION
Add 365Skill, a production-tested bilingual Agent Skill library (23 days old, 145+ commits, active development). Meets awesome list criteria.