### PR TITLE
Add Open Multi-Agent to Autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) - An open-source TypeScript framework for multi-agent workflows planned as task DAGs at runtime, with approval gates, tracing, evaluation, and checkpoint resume. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
## Summary

Add [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) to **Agents → Autonomous agents** using a concise, factual description and the existing `#opensource` marker.

## Main-list eligibility

At submission time the MIT-licensed repository has 6.7k+ GitHub stars, current releases, and maintained public documentation, satisfying the contribution guide's high-general-interest threshold of at least 1,000 followers.

The new entry is appended to the bottom of the category, as required by the contribution guide.

## Verification

- Checked the current README and open/closed issues and pull requests for the canonical repository URL and exact project name; no existing OMA submission was found.
- Confirmed the canonical repository link returns HTTP 200.
- Ran `git diff --check`.
- Ran the repository's `npx --yes awesome-lint .` check successfully using an isolated npm cache.

## Disclosure

I am a maintainer of Open Multi-Agent.
