### PR TITLE
Add TalkPix.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Seedance 2.0](https://seed.bytedance.com/en/seedance2_0) - An image-to-video and text-to-video model developed by Niobotics ByteDance.
 - [MaxVideoAI](https://maxvideoai.com/examples) - A workspace for generating and comparing videos across multiple AI video models.
 - [HyperFrames](https://hyperframes.heygen.com/) - A framework for AI agents to render videos by writing HTML, CSS, and JavaScript. [#opensource](https://github.com/heygen-com/hyperframes)
+- [TalkPix.ai](https://www.talkpix.ai/) - Pay-as-you-go AI video studio for talking photos, e-commerce product video ads, and text-to-video clips.
 
 ### Avatars
 


### PR DESCRIPTION
Add TalkPix.ai to the Video section. TalkPix.ai is a pay-as-you-go AI video studio that generates talking photos, product video ads for e-commerce, and text-to-video clips.