### PR TITLE
Add Open LLM to the list of resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [Open LLM](https://github.com/MilanSirko/Open-LLM) - One single, OpenAI-compatible API endpoint giving you access to 100+ free models across multiple top providers!
 
 ### Playgrounds
 


### PR DESCRIPTION
I added a Open source project: You can use 100+ free models with one API endpoint.