### PR TITLE
Add Peelaway to image service discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -203,6 +203,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [deAPI.ai](https://deapi.ai/) - A unified inference API to open-source AI models for text-to-image, text-to-speech, transcription, video generation, and more, using a decentralized GPU cloud.
 - [MyPicNow](https://www.mypicnow.com) - An AI headshot generator for creating professional profile photos from uploaded selfies.
 - [PhotoMentor](https://photomentor.pro) - An AI tool for analyzing photos and providing composition and lighting feedback.
+- [Peelaway](https://peelaway.io/editor?utm_source=awesome_generative_ai&utm_medium=referral&utm_campaign=pve-043&utm_content=discoveries_image_services) - A prompt-driven browser image editor for object removal, transparent-background results, and generative edits.
 
 ### Graphic design
 


### PR DESCRIPTION
## Summary

- Add Peelaway to **Image > Services** in the Discoveries list.
- Link to the prompt-driven browser editor with a concise description of its current object-removal, transparent-background, and generative-edit capabilities.

## Disclosure

I maintain Peelaway, so this is a self-submission. I prepared this one-line change with AI assistance and manually reviewed the placement, wording, destination, and diff.

The destination carries the exact attribution tuple `awesome_generative_ai / referral / pve-043 / discoveries_image_services`. I will use it only to measure aggregate attributed visitors, sessions, and `edit_submitted` events from this directory entry. This repository receives no Peelaway user data, and there is no payment or reciprocal placement.

The registered holdout repository, `eudk/awesome-ai-tools`, remains untouched.

## Validation

- The exact destination returns HTTP 200.
- The production contract supports object removal, background removal with transparent PNG results, and generative editing.
- `git diff --check` passes, with one insertion in `DISCOVERIES.md` and no other file changes.
