### PR TITLE
Add The Agents Index to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -295,5 +295,6 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Awesome AI Software Development Agents](https://github.com/flatlogic/awesome-ai-software-development-agents) - Curated list of AI agents designed for software development tasks.
 - [MODELDROP](https://modeldrop.fyi/) - A community tracker for new generative media AI model releases.
 - [MyVibe](https://www.myvibe.so) - A feed for discovering and sharing AI-created web apps, demos, and interactive projects.
+- [The Agents Index](https://theagentsindex.com) - A researched directory of AI agents, frameworks and agentic tools.
 
 ### Lists on ChatGPT


### PR DESCRIPTION
Adds The Agents Index (theagentsindex.com) to the Discoveries "More lists" section, alongside similar resources like The Rundown AI List and GPT Tracker.

The Agents Index is a researched directory of AI agents, frameworks and agentic tools — software that autonomously plans and acts, plus the frameworks/platforms used to build it. Every listing goes through a structured quality gate (sourced fields, fit-check) before publishing rather than being scraped/bulk-added.

Follows the CONTRIBUTING.md format (`[ProjectName](Link) - Description.`) and is appended to the bottom of the category as instructed.