### PR TITLE
Add Atomic Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Lovable](https://lovable.dev) - Conversational full-stack app generation, turning ideas into deployable code.
 - [aider](https://aider.chat/) - AI pair programming in your terminal, supporting multiple LLM providers. [#opensource](https://github.com/paul-gauthier/aider)
 - [Kilo](https://kilo.ai/) - Open-source AI coding assistant for VS Code, JetBrains, and the CLI. [#opensource](https://github.com/Kilo-Org/kilocode)
+- [Atomic Agent](https://atomicagent.io) - A local-first CLI and TUI coding agent that runs open-weight models entirely on your machine, with no account or API key required. [#opensource](https://github.com/AtomicBot-ai/atomic-agent)
 
 ### Developer tools
 
@@ -292,6 +293,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [Atomic Agent](https://atomicagent.io) - A local-first personal agent with 56 tools, MCP support, and local memory that runs open-weight models entirely on your machine. [#opensource](https://github.com/AtomicBot-ai/atomic-agent)
 
 ### Custom assistants
 


### PR DESCRIPTION
Hi Steven, thanks for maintaining this list, it's one of the best maps of the space.

I'm the CPO of Atomic Agent, and I'd love to add it. It's a local-first CLI and TUI coding agent: it runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required to install. It ships with 56 tools (browser, filesystem, git, memory, vision), MCP support, and a 5-layer local memory, on macOS, Linux, and Windows.

- Site: https://atomicagent.io
- Repo (MIT, ~2k stars): https://github.com/AtomicBot-ai/atomic-agent
- Docs: https://atomicagent.io/docs
- Install: `curl -fsSL https://atomicagent.io/install | sh`

It fits both Coding Assistants (terminal coding agent, alongside aider and Continue) and Autonomous agents (local-first personal agent), so I added one entry to each. Happy to trim to a single section if you'd prefer.
