### PR TITLE
Add OpenProgram to agent discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -176,6 +176,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 - [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
+- [OpenProgram](https://github.com/Fzkuji/OpenProgram) - A self-programming AI agent framework where agents create, run, and refine workflows across models, tools, memory, and context. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
Add OpenProgram to the Discoveries list under Agents / Autonomous agents.

OpenProgram is an actively maintained, documented open-source framework focused on self-programming agents that create, run, and refine workflows across models, tools, memory, and context. It is submitted to Discoveries because the project is still emerging and does not claim the Main List follower threshold.

Checks:
- Entry follows the documented `[ProjectName](Link) - Description.` format.
- Added at the bottom of the existing category.
- Repository link returns HTTP 200.
- `git diff --check` passes.