### PR TITLE
Add Wenlan to local search discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -52,6 +52,8 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 ### Local search engines
 
+- [Wenlan](https://github.com/7xuanlu/wenlan) - Local-first, source-backed AI knowledge base and LLM wiki for AI coding workflows. #opensource
+
 ### Writing assistants
 
 - [Yarnit](https://www.yarnit.app/) - Yarnit, a digital storytelling application that uses generative AI to storyboard, research and design your ideas.


### PR DESCRIPTION
## Summary

- add Wenlan to the existing Local search engines section in `DISCOVERIES.md`
- link the maintained open-source repository directly
- describe its local-first, source-backed AI knowledge-base and LLM-wiki role

## Why Discoveries

Wenlan is actively maintained and well documented, but it does not meet the main list's 1,000-follower threshold yet. The contribution guide explicitly provides Discoveries for valuable emerging projects.

## Validation

- one Discoveries entry only
- `git diff --check` passes
- no Wenlan or `7xuanlu/wenlan` duplicate on the default branch or across pull requests
- primary repository URL returns HTTP 200
- repository is Apache-2.0 and unarchived
- commit includes DCO sign-off