### PR TITLE
Add Inki to Discoveries - Writing assistants

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -67,6 +67,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [LogicBalls](https://logicballs.com/) - An AI writing tool for generating blog posts, ads, emails, and social media content. Includes a prompt library.
 - [Publish7](https://publish7.com/) - Agentic platform for digital marketing.
 - [WordLift Agent](https://wordlift.io/agent/) - AI agent for SEO tasks such as product descriptions, internal linking, and SERP analysis.
+- [Inki](https://inki.so/) - AI editor for drafting, rewriting, and review that learns your writing style by folder.
 
 ### ChatGPT extensions
 


### PR DESCRIPTION
## Summary

Adds Inki to the Discoveries list under Text > Writing assistants.

Inki is an AI editor for drafting, rewriting, and review. It learns the writing style saved for each folder and supports English and Japanese on the web and Mac.

I am submitting to Discoveries because Inki is a growing product and does not claim the Main List’s 1,000-follower threshold.

Disclosure: I am the maker.

## Verification

- Confirmed https://inki.so/ returns HTTP 200 and redirects to the English homepage.
- Kept the entry to the required `[ProjectName](Link) - Description.` format.