### PR TITLE
Add Seele TV to video discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -228,6 +228,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [Seele TV](https://seele.tv/) - Controllable AI video studio for reference-led cinematic sequences, camera direction, and scene continuity.
 
 ### Avatars
 


### PR DESCRIPTION
Adds Seele TV (https://seele.tv), a controllable AI video studio for reference-led cinematic sequences, shot-level camera direction, and scene continuity. The entry is placed in the repository's video-related section and uses a concise factual description.

Disclosure: submitted on behalf of Seele TV.
