### PR TITLE
Add Pixapi to Image Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 
 ### Services
 
+- [Pixapi](https://pixapi.ai) - Visual AI API with predictable credit pricing: see the cost before each request, then generate, edit images and run async video (Veo, Kling, Wan) through one Bearer-authenticated endpoint.
 - [Craiyon](https://www.craiyon.com/) - Craiyon, formerly DALL-E mini, is an AI model that can draw images from any text prompt.
 - [DreamStudio](https://stability.ai/dreamstudio) - DreamStudio is an easy-to-use interface for creating images using the Stable Diffusion image generation model.
 - [Artbreeder](https://www.artbreeder.com/) - Artbreeder is new type of creative tool that empowers users creativity by making it easier to collaborate and explore.


### PR DESCRIPTION
Add Pixapi to the Image > Services list: a visual AI API with predictable credit pricing - it shows the exact credit cost before each request and covers image generation, editing and async video (Veo, Kling, Wan) through one Bearer-authenticated endpoint.