### PR TITLE
Add videos.social (editable text-to-video) to Discoveries Video

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -229,6 +229,8 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
 
+- [videos.social](https://videos.social/?utm_source=awesome-genai&utm_medium=directory&utm_campaign=listing-wave-b) - Turns blog posts, PDFs, and prompts into editable faceless videos. Start free with 1 render included.
+
 ### Avatars
 
 ### Animation

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -229,7 +229,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
 
-- [videos.social](https://videos.social/?utm_source=awesome-genai&utm_medium=directory&utm_campaign=listing-wave-b) - Turns blog posts, PDFs, and prompts into editable faceless videos. Start free with 1 render included.
+- [videos.social](https://videos.social/) - Turns blog posts, PDFs, and prompts into editable faceless videos.
 
 ### Avatars
 


### PR DESCRIPTION
## Why

videos.social turns existing writing (blog posts, PDFs, prompts, research links) into an editable faceless video draft — script, scenes, voiceover — instead of a regenerate-only MP4.

Does not meet the Main List follower threshold yet, so this is a Discoveries addition per CONTRIBUTING.

## Entry

Added at the bottom of **Video** in `DISCOVERIES.md`:

- [videos.social](https://videos.social/?utm_source=awesome-genai&utm_medium=directory&utm_campaign=listing-wave-b) - Turns blog posts, PDFs, and prompts into editable faceless videos. Start free with 1 render included.

Pricing truth: 1 free render to start; packs from $10; 1 credit = 1 render.