### PR TITLE
Add FlowPix to Image > Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Reve Image](https://reve.com/) - A model trained from the ground up to excel at prompt adherence, aesthetics, and typography.
 - [Magnific](https://www.magnific.com/) - AI-powered design tools including image generation, background removal, and creative templates.
 - [FigureLabs](https://www.figurelabs.ai/) - An AI tool for generating publication-ready scientific figures in vector format from text descriptions or sketches.
+- [FlowPix](https://flowpix.ai) - AI image and video generation, editing and enhancement on one agentic canvas across 18+ models.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds [FlowPix](https://flowpix.ai) to the bottom of Image > Services, per the contribution guidelines.

FlowPix is an agentic canvas for AI visual creation: image and video generation, editing and enhancement across 18+ models (Flux, Kling, etc.) in one place. Free tier available without a card.

- Format follows the existing entries: `[Name](Link) - Description.`
- Added to the bottom of its category
- One entry, no other changes