### PR TITLE
Add SandBase to developer tools discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -148,6 +148,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Codeflash](https://www.codeflash.ai/) - An AI tool that automatically finds optimized versions of Python code through benchmarking.
 - [AgentAudit](https://github.com/jakops88-hub/AgentAudit-AI-Grounding-Reliability-Check) - A tool for verifying grounding and detecting unsupported claims in RAG pipeline outputs. #opensource
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
+- [SandBase](https://github.com/sandbaseai/cli) - Open-source CLI and MCP bridge for accessing 2,000+ AI models through one account. [#opensource](https://github.com/sandbaseai/cli)
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
 


### PR DESCRIPTION
## Summary

- add SandBase to Discoveries under Developer tools
- describe its open-source CLI and MCP access to 2,000+ AI models
- use the Discoveries list because the project does not meet the main list's follower threshold

## Validation

- confirmed there is no existing SandBase entry
- changed only `DISCOVERIES.md`
- ran `git diff --check`

## Disclosure

I am affiliated with SandBase. This submission was prepared with AI assistance and reviewed for factual accuracy and repository fit.
