### PR TITLE
Add RelayPlane to Discoveries (Developer tools)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [RelayPlane](https://github.com/RelayPlane/proxy) - An open-source cost-intelligence proxy and OpenAI-compatible LLM gateway that routes requests across 11 providers with smart model routing and a policy engine to cut API costs. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [RelayPlane](https://github.com/RelayPlane/proxy) to the Discoveries list under Coding > Developer tools.

RelayPlane is an open-source (MIT), OpenAI-compatible LLM gateway / cost-intelligence proxy: it routes requests across 11 providers with smart model routing and a policy engine to cut API costs. Similar in kind to GPTRouter and EvoLink already listed in this section.

Placed in Discoveries (not the Main List) since the project is under the 1,000-followers threshold in the contribution criteria. Entry uses the required format ([Name](link) - Description. #opensource) and is appended to the bottom of the Developer tools category per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)