### PR TITLE
Add Agent QA to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -176,6 +176,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 - [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
+- [Agent QA](https://github.com/vostride/agent-qa) - A self-improving QA agent for natural-language web and mobile tests with persistent test memory.
 
 ### Custom assistants
 


### PR DESCRIPTION
## Summary

Add Agent QA to **Discoveries > Agents > Autonomous agents**.

## Why Discoveries

Agent QA is a self-improving QA agent for natural-language web and mobile tests. It retains test memory and evidence across runs so repeated flows can adapt as interfaces change.

The project currently has 772 GitHub stars, so this submission intentionally uses `DISCOVERIES.md` rather than the main list's 1,000-star track. I also omitted the list's `#opensource` marker because the current FSL-1.1-ALv2 license is source-available and converts to Apache-2.0 after two years.

Repository: https://github.com/vostride/agent-qa

## Validation

- `git diff --check`
- standard awesome-lint run; the repository-wide run reports 83 existing errors and 2 warnings, with no diagnostic on the added line

Disclosure: I am affiliated with Agent QA and Vostride.