### PR TITLE
Add OpenH3-IR to DISCOVERIES.md

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -228,7 +228,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
-- [OpenH3-IR](https://github.com/ruashots/open-h3-ir) - H3 wants a long Context-IR prompt document, and MiniMax kept the part that writes it on their servers. An open take you run yourself: type a sentence, get that document, checked before it renders. Command line, HTTP, or its own ComfyUI nodes. #opensource
+- [OpenH3-IR](https://github.com/ruashots/open-h3-ir) - MiniMax published H3's Context-IR format but kept the part that writes it. An open one, not a prompt rewriter: type a sentence, get the document, checked first. Command line, HTTP, or its own ComfyUI nodes, on a model you already run. #opensource
 
 ### Avatars
 

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -228,6 +228,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [OpenH3-IR](https://github.com/ruashots/open-h3-ir) - H3 wants a long Context-IR prompt document, and MiniMax kept the part that writes it on their servers. An open take you run yourself: type a sentence, get that document, checked before it renders. Command line, HTTP, or its own ComfyUI nodes. #opensource
 
 ### Avatars
 


### PR DESCRIPTION
Adds OpenH3-IR under Video. Apache-2.0: https://github.com/ruashots/open-h3-ir

MiniMax published the format for H3's Context-IR document, the long structured prompt the model actually wants, and finished examples of it. What they kept on their own servers is the part that writes it. This is an open take on that part, and it is not a prompt enhancer: it writes the document to their published format, with the named sections in a fixed order, numbered picture labels, a length H3 can actually render, per-shot cut times, and sound described separately. Their own examples are in its test set and have to pass clean.

Two ways to use it: a command line with a small local service, and three ComfyUI nodes that use that same service from the canvas. It runs on whatever OpenAI-compatible model you already have and needs no GPU of its own.

Filed under Video rather than Developer tools because what it produces is video, and that is where a reader would look for it.
