### PR TITLE
Add AI Rookies to Learning resources

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -284,6 +284,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Gemini by Example](https://geminibyexample.com) - A hands-on introduction to the Gemini API and SDK through annotated code examples. [#opensource](https://github.com/strickvl/geminibyexample)
 - [Rearchitecting LLMs](https://www.manning.com/books/rearchitecting-llms) - A book about optimizing and restructuring LLMs for domain-specific use.
 - [PromptZone](https://promptzone.com/) - Community and publication for prompt engineering, LLM comparisons, and AI-tool workflows.
+- [AI Rookies](https://www.rookiesai.com) - A bilingual (English and Chinese) reference where each AI term is a card: a plain-language explanation on the front, and a mind map of how it connects to related concepts on the back.
 
 ## More lists
 


### PR DESCRIPTION
Adds [AI Rookies](https://www.rookiesai.com) to the Learning resources section of DISCOVERIES.md.

AI Rookies is a free bilingual (English / 中文) reference for AI terminology. Each term is a single card — a plain-language explanation on the front, and a mind map of how it relates to other concepts on the back. There are currently around 1,000 concepts, and reading requires no signup.

Disclosure: I built and maintain it. Submitting to Discoveries rather than the main list, since the project does not meet the 1,000-follower criterion.

- Added to the bottom of its category
- Format: `[Name](Link) - Description.`
- No trailing whitespace; `npx awesome-lint` reports no new issues on the added line