### PR TITLE
feat(tools): add GEOKit AI SEO & GEO toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Together AI](https://www.together.ai/) - Train, fine-tune-and run inference on AI models blazing fast, at low cost, and at production scale.
 - [Gitingest](https://gitingest.com/) - Turn any Git repository into a simple text digest of its codebase so it can be fed into any LLM. [#opensource](https://github.com/cyclotruc/gitingest)
 - [Repomix](https://repomix.com/) - Pack your codebase into AI-friendly formats. [#opensource](https://github.com/yamadashy/repomix)
+- [GEOKit](https://geokit.site) - Free Generative Engine Optimization (GEO) & AI SEO toolkit to optimize web presence for LLM ingestion, crawlers, and AI search engines.
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) - Inference of Meta's LLaMA model (and others) in pure C/C++. #opensource
 - [bitnet.cpp](https://github.com/microsoft/BitNet) - Official inference framework for 1-bit LLMs, by Microsoft. [#opensource](https://github.com/microsoft/BitNet)
 - [OpenRouter](https://openrouter.ai/) - A unified interface for LLMs. [#opensource](https://github.com/OpenRouterTeam)


### PR DESCRIPTION
### What does this PR do?

Adds [GEOKit](https://geokit.site) to the generative tools list.

### Details
- **Name**: GEOKit
- **Website**: https://geokit.site
- **Description**: Free Generative Engine Optimization (GEO) & AI SEO toolkit to optimize web presence for LLM ingestion, crawlers, and AI search engines.