### PR TITLE
Add Krealize

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -203,6 +203,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [deAPI.ai](https://deapi.ai/) - A unified inference API to open-source AI models for text-to-image, text-to-speech, transcription, video generation, and more, using a decentralized GPU cloud.
 - [MyPicNow](https://www.mypicnow.com) - An AI headshot generator for creating professional profile photos from uploaded selfies.
 - [PhotoMentor](https://photomentor.pro) - An AI tool for analyzing photos and providing composition and lighting feedback.
+- [Krealize](https://krealize.app/) - A native macOS app for local Krea 2 image generation on Apple silicon using MLX.
 
 ### Graphic design
 


### PR DESCRIPTION
## Summary

Add Krealize to `DISCOVERIES.md` under Image → Services.

Krealize is a native macOS app for running Krea 2 image generation locally on Apple silicon using MLX. Prompts, inference, and generated images stay on the Mac.

I selected the Discoveries list because Krealize is new and does not yet meet the main list's general-interest threshold.

## Validation

- Used the required `[Project](Link) - Description.` format.
- Confirmed https://krealize.app/ is publicly accessible.
- Checked for an existing Krealize entry or submission.

Disclosure: I am the creator of Krealize.