### PR TITLE
Add AI Architect Academy to Discoveries → Learning resources

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -284,6 +284,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Gemini by Example](https://geminibyexample.com) - A hands-on introduction to the Gemini API and SDK through annotated code examples. [#opensource](https://github.com/strickvl/geminibyexample)
 - [Rearchitecting LLMs](https://www.manning.com/books/rearchitecting-llms) - A book about optimizing and restructuring LLMs for domain-specific use.
 - [PromptZone](https://promptzone.com/) - Community and publication for prompt engineering, LLM comparisons, and AI-tool workflows.
+- [AI Architect Academy](https://aiarch.dev) - Build-first training for senior engineers moving into AI engineering and architecture, across the Anthropic, AWS and Cloudflare platforms, with preparation for the AWS and Anthropic certifications. Currently waitlist-only.
 
 ## More lists
 


### PR DESCRIPTION
Adds AI Architect Academy to the Discoveries list under Learning resources.

Submitting straight to Discoveries rather than the main list: the project does not meet the main list's 1,000-follower criterion, and CONTRIBUTING says such entries are routed here anyway.

What it is: a build-first curriculum for experienced software engineers moving into AI engineering and architecture — agentic systems, retrieval, evals, cost modelling and governance across the Anthropic, AWS and Cloudflare platforms, aligned to the AWS and Anthropic certification exam guides. The platform is itself built the way it teaches, and the architecture write-ups are published. Access is waitlist-only at the moment.

Disclosure: I'm affiliated with aiarch.dev.