### PR TITLE
Add Awesome AI Companion to More lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Awesome Music AI](https://github.com/steven2358/awesome-music-ai) - A curated list of AI tools for music composition, generation, and analysis.
 - [Awesome AI Market Maps](https://github.com/joylarkin/Awesome-AI-Market-Maps) - A curated list of AI market maps from 2026, 2025, and 2024, by [Joy Larkin](https://twitter.com/joy).
 - [Awesome RAG Production](https://github.com/Yigtwxx/Awesome-RAG-Production) - A curated list of tools and resources for building production RAG systems.
+- [Awesome AI Companion](https://github.com/DasterProkio/awesome-ai-companion) - A curated list of long-term AI companion systems: clients, memory, proactive behavior, embodiment, and shared activities.
 
 ### Lists on ChatGPT
 


### PR DESCRIPTION
Adds [Awesome AI Companion](https://github.com/DasterProkio/awesome-ai-companion) to the **More lists** section, at the bottom of the category per the contribution guidelines.

**What it covers:** long-term AI companion systems — chat clients, memory and identity layers, proactive behavior engines, embodiment, shared activities, and continuity tooling. 160 entries, each tagged with language, platform, and readiness status, plus a full Chinese translation kept in sync.

**On the quality standards:**
- *Well-documented*: every entry was verified against the linked project's own source or docs, with factual caveats recorded where relevant (unmaintained upstreams, non-commercial licenses, missing client source).
- *Actively maintained*: the index is updated continuously and passes `npx awesome-lint`; link checking covers all 148 linked GitHub repositories.
- *Useful to the community*: the companion/persistent-relationship corner of generative AI has no other maintained index — the existing lists here cover agents, RAG, music, and market maps, but not this vertical.

The repository has 445 stars, so it falls short of the 1,000-follower threshold for the Main List. Happy for it to go to [Discoveries](DISCOVERIES.md) instead if you prefer — I placed it in More lists because that section indexes other curated lists rather than individual products.

Web index: https://lutopia.app/companion/
