### PR TITLE
Add tokensto.cash

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -268,6 +268,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [KeepRule](https://keeprule.com) - Investment-discipline tool with curated principles from 26 investors and AI prompts for scenario analysis.
 - [GEOScore AI](https://geoscoreai.com/) - Free AI search visibility scanner that checks 11 GEO signals for ChatGPT, Perplexity, and Gemini visibility.
 - [DeepDNA](https://deepdna.ai) - AI-powered DNA analysis platform for personalized health, nutrition, and pharmacogenomic insights from consumer genetic data.
+- [tokensto.cash](https://tokensto.cash) - Sell unused generative-AI API credits on Surplus Intelligence and get paid USDC per request.
 
 ## Learning resources
 

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -268,7 +268,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [KeepRule](https://keeprule.com) - Investment-discipline tool with curated principles from 26 investors and AI prompts for scenario analysis.
 - [GEOScore AI](https://geoscoreai.com/) - Free AI search visibility scanner that checks 11 GEO signals for ChatGPT, Perplexity, and Gemini visibility.
 - [DeepDNA](https://deepdna.ai) - AI-powered DNA analysis platform for personalized health, nutrition, and pharmacogenomic insights from consumer genetic data.
-- [tokensto.cash](https://tokensto.cash) - Sell unused generative-AI API credits on Surplus Intelligence and get paid USDC per request.
+- [tokensto.cash](https://tokensto.cash) - Sell unused generative-AI API credits on Surplus Intelligence and get paid USDC per request. Cash out to Revolut, Monzo, Chime, Zelle, Venmo, Cash App, Wise, or PayPal (Verify handshake for the last four).
 
 ## Learning resources
 


### PR DESCRIPTION
Adds [tokensto.cash](https://tokensto.cash) to Discoveries > Other (new product; does not meet the 1k-follower bar for the main list). Live marketplace to sell unused generative-AI API credits; listing is free. Paid USDC per request on Base; live cash-out rails are Revolut, Monzo, Chime, and Zelle.