### PR TITLE
Add WaveSpeed to Image Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Reve Image](https://reve.com/) - A model trained from the ground up to excel at prompt adherence, aesthetics, and typography.
 - [Magnific](https://www.magnific.com/) - AI-powered design tools including image generation, background removal, and creative templates.
 - [FigureLabs](https://www.figurelabs.ai/) - An AI tool for generating publication-ready scientific figures in vector format from text descriptions or sketches.
+- [WaveSpeed](https://wavespeed.ai/) - Run the latest image and video generation models (Seedream, Seedance, FLUX, Wan and more) through one fast API and web playground.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds [WaveSpeed](https://wavespeed.ai/) — a platform to run the latest image and video generation models (Seedream, Seedance, FLUX, Wan, and more) through one fast API and web playground. Serves millions of generations for developers and creative teams.

Follows the contribution guidelines: single entry, added to the bottom of its category (Image → Services), `[Name](Link) - Description.` format.