### PR TITLE
Add VidWords to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [NotebookLM](https://notebooklm.google/) - A research and note-taking online tool to interact with documents, powered by Google Gemini.
 - [Open Notebook](https://www.open-notebook.ai) - An open source implementation of NotebookLM with more flexibility and features. [#opensource](https://github.com/lfnovo/open-notebook)
 - [Screenpipe](https://github.com/screenpipe/screenpipe) - An open-source tool for recording screen and audio activity with AI-powered search, automations, and support for local LLMs. #opensource
+- [VidWords](https://vidwords.com) - Turn a YouTube video into a searchable transcript or an AI summary in which every claim carries a clickable timestamp.
 
 ### Meeting assistants
 


### PR DESCRIPTION
Adds one entry to the bottom of **Text → Productivity**, alongside ChatPDF and
NotebookLM — tools that make a document or recording queryable. VidWords is the
same idea pointed at YouTube.

```
- [VidWords](https://vidwords.com) - Turn a YouTube video into a searchable transcript or an AI summary in which every claim carries a clickable timestamp.
```

Formatting: `[Name](Link) - Description.`, appended to the bottom of its category,
description ends with a period, no trailing whitespace.

**Disclosure:** I maintain this tool.

**On the inclusion criteria:** I can't claim 1,000+ followers, so by your own rules this
probably belongs in Discoveries rather than the Main List — please move it there, that's
a fine outcome. The one thing that may be of interest for the main list is the citation
behaviour: the summariser refuses to answer rather than guess when the transcript doesn't
support a claim, and every statement it does make links to the timestamp it came from.

Not open source, so no `#opensource` tag. Free tier requires no card.
