### PR TITLE
Add Murmell (Multi-agent collaborative coding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [Murmell](https://murmell.com) - A browser canvas where multiple AI coding agents (Claude Code, Codex, Kimi, OpenCode) run together on a shared cloud VM with per-file claims, so agents work on the same repo at once without overwriting each other.
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds Murmell (https://murmell.com) to Autonomous agents: a browser canvas where multiple AI coding agents (Claude Code, Codex, Kimi, OpenCode) run together on a shared cloud VM with per-file claims, so agents work on the same repo at once without overwriting each other.