### PR TITLE
Add Chat Threads

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -73,6 +73,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AI Character for GPT](https://chromewebstore.google.com/detail/ai-character-for-gpt/daoeioifimkjegafelcaljboknjkkohh) - Easily customize AI chatbots like ChatGPT and Google Gemini for better responses.
 - [AI Summary Helper](https://chromewebstore.google.com/detail/ai-summary-helper-openai/hldbejcjaedipeegjcinmhejdndchkmb) - Get AI summaries of web content. Use Send To Kindle for reading on the go. [#opensource](https://github.com/philffm/ai-summary-helper)
 - [Chatgpt Light Session](https://chromewebstore.google.com/detail/fmomjhjnmgpknbabfpojgifokaibeoje) - A browser extension for trimming long ChatGPT conversations in the UI.
+- [Chat Threads](https://github.com/onyourmark/chat-threads) - Open-source side panel that removes unwanted turns from a long ChatGPT or Claude conversation and splits it into separate topic conversations, on a copy that leaves the original untouched.
 
 ### Productivity
 


### PR DESCRIPTION
Adding [Chat Threads](https://github.com/onyourmark/chat-threads) to the **Discoveries** list, under *Text → ChatGPT extensions*.

Submitting to Discoveries rather than the Main List deliberately: the project is new and does not yet meet the 1,000-follower criterion in CONTRIBUTING.md.

What it is: an open-source (MIT) Chrome and Edge side panel for reshaping a long ChatGPT or Claude conversation. You can read back only your own prompts, exclude or edit individual turns, and split one conversation into separate topic conversations to paste into a new chat. It works on a copy and issues read requests only, so the original conversation is never modified.

No backend, no account, no analytics. It holds no host permissions at install time — `activeTab` means it can only read a tab after you click its toolbar icon. Topic suggestions are optional and use the user's own OpenAI or Anthropic API key; everything else runs locally with no network requests.

Not affiliated with OpenAI or Anthropic.