### PR TITLE
Add Epovest to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -268,6 +268,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [KeepRule](https://keeprule.com) - Investment-discipline tool with curated principles from 26 investors and AI prompts for scenario analysis.
 - [GEOScore AI](https://geoscoreai.com/) - Free AI search visibility scanner that checks 11 GEO signals for ChatGPT, Perplexity, and Gemini visibility.
 - [DeepDNA](https://deepdna.ai) - AI-powered DNA analysis platform for personalized health, nutrition, and pharmacogenomic insights from consumer genetic data.
+- [Epovest](https://epovest.com/) - Measures how AI assistants answer the questions a market asks, which sources they cite, and where to act.
 
 ## Learning resources
 


### PR DESCRIPTION
Adds Epovest to the `Other` section of DISCOVERIES.md, at the bottom of the category as the guidelines ask.

`- [Epovest](https://epovest.com/) - Measures how AI assistants answer the questions a market asks, which sources they cite, and where to act.`

Epovest puts a fixed panel of prompts to the AI engines through their official APIs, archives every answer with the sources it cited, and tracks how that changes over time. Closest neighbour already on the list is GEOScore AI, in the same section.

Happy to reword or move it if another category fits better.