### PR TITLE
Add Vibe-Coding Prompt Template to Coding > Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [Vibe-Coding Prompt Template](https://github.com/KhazP/vibe-coding-prompt-template) - A staged prompt workflow that turns a product idea into a PRD, a technical design, and the AGENTS.md instruction files an AI coding agent builds from. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds one entry to the bottom of **Coding → Developer tools**.

```markdown
- [Vibe-Coding Prompt Template](https://github.com/KhazP/vibe-coding-prompt-template) - A staged prompt workflow that turns a product idea into a PRD, a technical design, and the AGENTS.md instruction files an AI coding agent builds from. #opensource
```

**Disclosure:** this is my own project.

Against the contribution guidelines:

- **Format** — `[ProjectName](Link) - Description.`, added to the **bottom** of its category, single sentence ending in a period, no trailing whitespace.
- **Inclusion criterion 1** — 2.8k stars, 360+ forks, comfortably over the 1,000 threshold.
- **Actively maintained** — commits within the last day; CLI published on npm as `vibeworkflow`.
- **Well documented** — README walks all five steps, plus `docs/` and `examples/`; each prompt is its own file in the repo.
- **Open source** — MIT, hence the `#opensource` tag matching the convention in that section.

It complements rather than duplicates the tools already there: Gitingest and Repomix package an existing codebase for an LLM; this produces the planning documents and agent instructions before a codebase exists.
