### PR TITLE
Add aicoolies to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -295,5 +295,6 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Awesome AI Software Development Agents](https://github.com/flatlogic/awesome-ai-software-development-agents) - Curated list of AI agents designed for software development tasks.
 - [MODELDROP](https://modeldrop.fyi/) - A community tracker for new generative media AI model releases.
 - [MyVibe](https://www.myvibe.so) - A feed for discovering and sharing AI-created web apps, demos, and interactive projects.
+- [aicoolies](https://aicoolies.com) - Hand-tested developer-tools knowledge graph of 1280+ AI tools, comparisons, reviews, and stacks.
 
 ### Lists on ChatGPT


### PR DESCRIPTION
I am the maker of [aicoolies](https://aicoolies.com).

This is a catalog / resource (a hand-tested developer-tools knowledge graph of 1280+ AI tools, comparisons, reviews, and stacks). It is not a coding agent or LLM tool.

Per CONTRIBUTING.md, this is not submitted to the main list (1k-follower bar). Added to **DISCOVERIES.md → More lists**, the related/catalogs bucket for directories of tools. That is the right slot.

Exact line:

`- [aicoolies](https://aicoolies.com) - Hand-tested developer-tools knowledge graph of 1280+ AI tools, comparisons, reviews, and stacks.`