### PR TITLE
Add iLostCount to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [iLostCount](https://ilostcount.com) - Free browser-based counter for tokens, words and characters in LLM prompts.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adding my own project to the Discoveries list, under Coding > Developer tools.

iLostCount is a free, no-signup web page that counts tokens, words and characters in text as you type, for people writing LLM prompts and checking context limits. It runs entirely in the browser, with no account and no upload. Source: https://github.com/ahmad-almazeedi/token-counter

Placed in the Discoveries list since it does not meet the main list follower bar.