### PR TITLE
Add MiniMax H3 1K prompt curation to the Video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,10 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [MaxVideoAI](https://maxvideoai.com/examples) - A workspace for generating and comparing videos across multiple AI video models.
 - [HyperFrames](https://hyperframes.heygen.com/) - A framework for AI agents to render videos by writing HTML, CSS, and JavaScript. [#opensource](https://github.com/heygen-com/hyperframes)
 
+### Video prompts
+
+- [MiniMax H3 1K prompt index](https://github.com/yangzhou-chaofan/minimax-h3-1000-prompts) - Curated 1K prompt dataset for MiniMax H3 text-to-video: prompt anatomy, 10 hand-picked prompts, model comparison.
+
 ### Avatars
 
 - [D-ID](https://www.d-id.com/) - Create and interact with talking avatars at the touch of a button.


### PR DESCRIPTION
Add MiniMax H3 1K prompt curation to the Video section

A curated index of the MiniMax H3 1K prompt dataset for text-to-video
generation: 3-field prompt anatomy, 10 hand-picked reusable prompts, and an
H3 vs. peer model comparison — plus an interactive atlas of all 1,000 clips.

Links:
- Interactive atlas of all 1,000 H3 clips: https://neta.art/use-cases/en/h3-1000-prompt-list
- Curated index repo: https://github.com/yangzhou-chaofan/minimax-h3-1000-prompts
- Original dataset (ostris/minimax_h3_1k): https://huggingface.co/datasets/ostris/minimax_h3_1k
