### PR TITLE
Add LLM API pricing to Discoveries - Leaderboards

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -101,6 +101,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 - [Price Per Token](https://pricepertoken.com/) - A tool for comparing LLM API pricing, token usage, and model benchmarks.
 - [Rival](https://rival.tips) - Leaderboard ranking 200+ AI models based on blind A/B human preference votes.
+- [LLM API pricing](https://xyzs996.github.io/llm-api-pricing/) - A daily-regenerated price table for the models coding agents run on, keeping the second and higher rate card that switches on for long prompts and bills every token in the request. [#opensource](https://github.com/xyzs996/llm-api-pricing)
 
 ### Other text generators
 

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -101,7 +101,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 - [Price Per Token](https://pricepertoken.com/) - A tool for comparing LLM API pricing, token usage, and model benchmarks.
 - [Rival](https://rival.tips) - Leaderboard ranking 200+ AI models based on blind A/B human preference votes.
-- [LLM API pricing](https://xyzs996.github.io/llm-api-pricing/) - A daily-regenerated price table for the models coding agents run on, keeping the second and higher rate card that switches on for long prompts and bills every token in the request. [#opensource](https://github.com/xyzs996/llm-api-pricing)
+- [LLM API pricing](https://xyzs996.github.io/llm-api-pricing/) - Daily-regenerated price table for the 60 models coding agents run on, with cached-input rates and, where vendors publish one, the long-context tier. [#opensource](https://github.com/xyzs996/llm-api-pricing)
 
 ### Other text generators
 


### PR DESCRIPTION
Adds one entry to **Discoveries → Leaderboards**, below Price Per Token.

- **Link:** https://xyzs996.github.io/llm-api-pricing/
- **Source:** https://github.com/xyzs996/llm-api-pricing — MIT, regenerated daily by CI, no signup, no tracker.

### Why it is not a duplicate of the entry above it

Almost every published price table prints one number per model. A growing share of models do not have one. The catalog those tables read from publishes a second rate card that switches on once the prompt passes a threshold, and it is a cliff rather than a marginal tier — xAI's own docs say the higher rate applies *"for all tokens in the request"*, so one token over the line roughly doubles the bill for the whole call, including the tokens below the threshold.

On today's snapshot that second card is on 12 of the 60 rows, at two thresholds. The widest gap: `x-ai/grok-4.20` advertises 2,000k of context at $1.25/M input and steps to $2.50 at 200k, so 90% of the advertised window bills at a number that is not printed in its own row.

This table keeps that column, and ships it in the JSON and CSV as well as on the page. Every figure carries the source it was read from and the date it was read.

### Checklist

- [x] Format is `[ProjectName](Link) - Description.`
- [x] Added at the bottom of its category
- [x] Description is one sentence and ends with a period
- [x] Open source, so tagged `#opensource` with the repository link
- [x] Submitted to Discoveries rather than the main list — the project does not meet the follower threshold
