### PR TITLE
Add Persona to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Agent Skills](https://agentskills.io) - Open format and reference SDK for packaging reusable capabilities and expertise for AI agents. [#opensource](https://github.com/agentskills/agentskills)
 - [PraisonAI](https://github.com/MervinPraison/PraisonAI) - A framework for building multi-agent AI systems with workflows, tool integrations, and memory. #opensource
 - [Hermes Agent](https://hermes-agent.nousresearch.com) - A self-improving personal agent with memory, messaging integrations, and sandboxed tool execution. [#opensource](https://github.com/NousResearch/hermes-agent)
+- [Persona](https://github.com/jayamitkatariya/personacli) - A local-first personal workspace: notes and tasks as plain Markdown on your machine, with an AI chat grounded in your own files. [#opensource](https://github.com/jayamitkatariya/personacli)
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource


### PR DESCRIPTION
Adds [Persona](https://github.com/jayamitkatariya/personacli) under **Agents → Autonomous agents**.

Persona is a local-first personal workspace: Markdown notes and tasks stored on the user's machine, with an AI chat grounded in those files. Runs on Ollama or any OpenAI-compatible API. MIT.