### PR TITLE
Add 2000+ Most Visited AI Websites to More lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Awesome Music AI](https://github.com/steven2358/awesome-music-ai) - A curated list of AI tools for music composition, generation, and analysis.
 - [Awesome AI Market Maps](https://github.com/joylarkin/Awesome-AI-Market-Maps) - A curated list of AI market maps from 2026, 2025, and 2024, by [Joy Larkin](https://twitter.com/joy).
 - [Awesome RAG Production](https://github.com/Yigtwxx/Awesome-RAG-Production) - A curated list of tools and resources for building production RAG systems.
+- [2000+ Most Visited AI Websites](https://www.stackscan.com/lists/ai-websites) - AI platforms and tools ranked by estimated monthly traffic, with monthly unique visitors per site. Updated monthly.
 
 ### Lists on ChatGPT
 


### PR DESCRIPTION
Adds a ranked directory of AI websites to **More lists**.

It ranks 2,187 AI platforms, tools and services by estimated monthly traffic, highest first, showing monthly unique visitors for each. Drawn from 50M+ tracked domains and refreshed monthly, so the ordering reflects current traffic rather than a snapshot from whenever the page was written.

The section already collects market maps and Airtable directories of the generative AI space. This covers the same ground with traffic as the ordering, which makes it useful for seeing which AI products actually have reach against which are simply well known.

Free to browse, no account needed.
