### PR TITLE
Add OpenOutreach to Autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [OpenOutreach](https://github.com/eracle/OpenOutreach) - A self-hosted B2B lead finder that discovers candidates from licensed data, qualifies each one against your ideal customer profile, and exports the reason it chose them. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds **OpenOutreach** to *Agents → Autonomous agents*, at the bottom of the category, in the list's format.

It is an open-source B2B lead finder I maintain. You describe your product; it discovers candidate companies and people from a licensed data source, has an LLM judge each candidate against your ideal customer profile, and exports the campaign as CSV with the reason for each lead written out. A per-campaign Gaussian Process learns from those LLM verdicts and decides who to evaluate next, so the one paid enrichment step is spent where the model expects a hit rather than uniformly. Self-hosted and bounded: `uvx openoutreach find 10 > leads.csv` prints the campaign and exits.

On the inclusion criteria — the repo is at 2,805 stars, which clears the 1,000 bar for the Main List. It is GPL-3.0, actively maintained, and documented at https://openoutreach.app. If you would rather it sat in DISCOVERIES.md, that is fine by me; say the word and I will move the line.

Repo: https://github.com/eracle/OpenOutreach
