### PR TITLE
Add AI Engineer Notebooks to Learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [AI Governance](https://www.manning.com/books/ai-governance) - A book about governance, risk, compliance, security, privacy, and oversight for generative AI systems.
 - [AnimatedLLM](https://animatedllm.github.io/) - Interactive visualizations explaining how large language models work. [#opensource](https://github.com/kasnerz/animated-llm)
 - [Transformer Explainer](https://poloclub.github.io/transformer-explainer/) - Interactive visualization of how transformer-based LLMs work, running a live GPT-2 model in the browser. [#opensource](https://github.com/poloclub/transformer-explainer)
+- [AI Engineer Notebooks](https://github.com/calmrocks/ai-engineer-notebooks) - Framework-free Colab notebooks teaching the applied-LLM / AI Engineer stack (APIs, RAG, evals, agents, fine-tuning vs LoRA, security, LLMOps) on the free Groq API. [#opensource](https://github.com/calmrocks/ai-engineer-notebooks)
 
 ## More lists
 


### PR DESCRIPTION
Adds AI Engineer Notebooks to Learning resources (understood it may route to Discoveries given it's under 1k stars). Framework-free, hands-on notebook course for the applied-LLM stack, runnable on the free Groq API.

Disclosure: I'm the author.