### PR TITLE
Add Cortex under Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [Cortex](https://cortex-rbx.github.io) - An OpenAI-compatible AI API for adding LLMs to Roblox games (talking NPCs, quests, moderation) from one server-side request.
 
 ### Playgrounds
 


### PR DESCRIPTION
Cortex is an OpenAI-compatible AI API for adding LLMs to Roblox games (talking NPCs, quests, moderation) from one server-side request — similar in spirit to the API gateways already listed (OpenRouter, Together). Site: https://cortex-rbx.github.io