### PR TITLE
Add OrcaRouter Lite to Discoveries - Developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [OrcaRouter Lite](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite) - A self-hosted, OpenAI-compatible LLM router with bring-your-own-key routing across 100+ models, automatic failover, streaming, and cost/latency-based model selection. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds OrcaRouter Lite to the Discoveries list under Coding → Developer tools.

Self-hosted, OpenAI-compatible LLM router: bring your own provider keys, route across 100+ models with automatic failover and streaming, and `model="auto"` selects by cost, latency, or quality. MIT licensed, actively maintained.

Submitted to Discoveries rather than the Main List: at ~590 stars the project does not yet meet the 1,000-follower criterion in CONTRIBUTING.md. Same genre as GPTRouter and EvoLink, already in this section.

Disclosure: I contribute to OrcaRouter Lite.
