### PR TITLE
Add Longscribe to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [NotebookLM](https://notebooklm.google/) - A research and note-taking online tool to interact with documents, powered by Google Gemini.
 - [Open Notebook](https://www.open-notebook.ai) - An open source implementation of NotebookLM with more flexibility and features. [#opensource](https://github.com/lfnovo/open-notebook)
 - [Screenpipe](https://github.com/screenpipe/screenpipe) - An open-source tool for recording screen and audio activity with AI-powered search, automations, and support for local LLMs. #opensource
+- [Longscribe](https://longscribe.com/) - Free AI transcription for long audio, video and podcasts. Paste a YouTube, Vimeo, TikTok or podcast link and get clean text, SRT subtitles or a Word document, no length limits.
 
 ### Meeting assistants
 


### PR DESCRIPTION
Adds [Longscribe](https://longscribe.com/), a free AI transcription tool for long-form audio, video and podcasts. Paste a public YouTube/Vimeo/TikTok/etc. link (or upload a file) and get clean text, timed SRT subtitles, or a Word document — no length cap on the free tier, long recordings process in the background.

Placed next to Screenpipe/Open Notebook, the other recording/transcription-adjacent tools already in Productivity.