### PR TITLE
Add CreateForge AI to Video discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -228,6 +228,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [CreateForge AI](https://createforgeai.com/) - Multi-model image and video generation workspace with an [open-source prompt workflow lab](https://github.com/Mr-ZhangBo/ai-model-prompt-brief-builder) for comparing 17 model profiles and exporting creative briefs.
 
 ### Avatars
 


### PR DESCRIPTION
Adds CreateForge AI to the Discoveries > Video section, following the contribution guidance for up-and-coming projects.\n\nThe entry uses one objective sentence, links the multi-model image and video workspace directly, and includes the public MIT-licensed UI Lab as a verifiable open-source companion. Both URLs return HTTP 200, and the change is exactly one line in DISCOVERIES.md.\n\nI maintain the submitted project.