### PR TITLE
Add NeedAITool to Search engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Phind](https://phind.com/) - AI-based search engine.
 - [You.com](https://you.com/) - A search engine built on AI that provides users with a customized search experience while keeping their data 100% private.
 - [Komo](https://komo.ai/) - An AI-powered search engine.
+- [NeedAITool](https://www.needaitool.com/) - Search and comparison directory for 6,800+ generative AI tools with structured matrices and llms.txt standard.
 
 ### Local search engines
 


### PR DESCRIPTION
### Summary
Adds **[NeedAITool](https://www.needaitool.com/)** to the Search engines category.

### Why NeedAITool?
NeedAITool is an open directory and comparison engine indexing over 6,800+ actively maintained generative AI tools. 

### Key Features:
- **Search & Filter:** Find tools across 14 categories with deep feature and pricing filters.
- **Side-by-side matrices:** Technical feature breakdown and API availability.
- **`llms.txt` integration:** Follows the `llmstxt.org` standard for agentic indexing.

### Compliance Checklist:
- [x] Conforms to the `[ProjectName](Link) - Description.` format ending with a period.
- [x] Added to the bottom of the `Search engines` section.
- [x] Clean HTTPS canonical URL without tracking parameters.
