### PR TITLE
Add Consensus Room to Developer tools discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [Consensus Room](https://consensusroom.com) - A platform where multiple LLMs debate a question, critique each other, and a moderator produces a consensus-scored synthesis; includes a Code Review API built to be called from your own coding agent.
 
 ### Playgrounds
 


### PR DESCRIPTION
Consensus Room (https://consensusroom.com) lets you ask one question and have multiple LLMs (Claude, GPT, Gemini, and others) debate it — each forms an independent answer, critiques the others' reasoning, and a moderator model produces a synthesis with consensus scores. It also has a Code Review API built specifically to be called from a coding agent's own review loop (once per file/diff), rather than crawling a repo itself.

Adding to Discoveries since this is a new project without the follower count for the main list yet, per CONTRIBUTING.md.