### PR TITLE
Add Piclisto to Image Services discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -203,6 +203,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [deAPI.ai](https://deapi.ai/) - A unified inference API to open-source AI models for text-to-image, text-to-speech, transcription, video generation, and more, using a decentralized GPU cloud.
 - [MyPicNow](https://www.mypicnow.com) - An AI headshot generator for creating professional profile photos from uploaded selfies.
 - [PhotoMentor](https://photomentor.pro) - An AI tool for analyzing photos and providing composition and lighting feedback.
+- [Piclisto](https://piclisto.com/product-page-kit) - Builds reviewable PDP, Amazon A+, and Shopify product-page image modules from one product SKU.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds Piclisto to the Image > Services section of DISCOVERIES.md. I am submitting it on behalf of the product team. The entry links directly to the Product Page Kit instead of the homepage and uses a concise factual description.