### PR TITLE
Add AIVideoAdherenceGate to Discoveries (Video)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -228,6 +228,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [AIVideoAdherenceGate](https://github.com/madebysaira/AIVideoAdherenceGate) - Offline post-render semantic and motion health gate for AI video that checks whether a rendered clip honored the creative contract and is physically healthy (motion, morph-drift, lip-sync).
 
 ### Avatars
 


### PR DESCRIPTION
## Summary
Adds [AIVideoCreditGuard](https://github.com/madebysaira/AIVideoCreditGuard) to the **Discoveries (Video)** section per CONTRIBUTING (repo has <1,000 followers; Discoveries is the correct home for new tools).

An offline pre-generation guard that lints prompts, estimates real cost (sticker × retries), and flags morph/consistency risks before Kling, Veo, or Runway burns a credit. No API keys. Pure Python 3 + ffmpeg. 10 passing tests.

## Convention compliance
- ✅ Placed in Discoveries (Video) per the >1,000-follower Main List rule
- ✅ Entry follows the existing '- [Name](url) - desc.' format
- ✅ Repo link returns HTTP 200
- ✅ Markdown structure preserved

> Friendly follow-up (still open since Aug 27): the PR is unchanged and valid — re-verified links return HTTP 200. Part of the madebysaira AIVideo* safety net with AIVideoAdherenceGate (#182/#184 on showlab/Awesome-Video-Diffusion).