### PR TITLE
Add Luphra to Image Services (Discoveries)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -203,6 +203,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [deAPI.ai](https://deapi.ai/) - A unified inference API to open-source AI models for text-to-image, text-to-speech, transcription, video generation, and more, using a decentralized GPU cloud.
 - [MyPicNow](https://www.mypicnow.com) - An AI headshot generator for creating professional profile photos from uploaded selfies.
 - [PhotoMentor](https://photomentor.pro) - An AI tool for analyzing photos and providing composition and lighting feedback.
+- [Luphra](https://www.luphra.com/) - Prompt-to-matter: turn text and sketches into editable 3D and manufactured physical products.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds [Luphra](https://www.luphra.com/) to Discoveries under Image → Services.

Prompt-to-matter: turns text and sketches into editable 3D and manufactured physical products. Fits the Discoveries list (new product, not yet at the main-list follower bar).