### PR TITLE
Add piighost to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [piighost](https://github.com/Athroniaeth/piighost) - Protect personal data (PII) in LLM prompts and agents. Hides sensitive values from the model, then restores the real values for tools and the user. Pluggable regex, NER, and LLM detectors, with LangChain and Pydantic AI integrations. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds [piighost](https://github.com/Athroniaeth/piighost) to Developer tools. It protects personal data (PII) in LLM prompts and agents: it hides sensitive values from the model, then restores the real values for tools and the user, with pluggable regex/NER/LLM detectors and LangChain / Pydantic AI integrations. Open source (MIT), on PyPI as `piighost`. Similar in spirit to the `rehydra` entry already listed.