### PR TITLE
Add prompt-lib to Text > Productivity (Discoveries)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -85,6 +85,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [SageCollab](https://sagecollab.com/) - SageCollab brings team collaboration features to generative AI.
 - [Worksheets.ai](https://www.worksheets.ai/) - Generate educational worksheets and lesson plans with AI.
 - [Recall](https://www.recall.it/) - A self-organizing knowledge base, where you can summarize and chat with any online content.
+- [prompt-lib](https://prompt-lib.org) - Free, copy-paste library of fill-in-the-blank AI prompts organized by job and task.
 
 ### Meeting assistants
 - [Goelo](https://www.goelo.com/) - Goelo helps sales teams automatically fill their CRM by recording meetings to create summaries and generate a knowledge base.


### PR DESCRIPTION
Adds **prompt-lib** to the Discoveries list under **Text > Productivity**.

`- [prompt-lib](https://prompt-lib.org) - Free, copy-paste library of fill-in-the-blank AI prompts organized by job and task.`

- Free, no sign-up, works with ChatGPT/Claude/Gemini (model-agnostic plain text).
- 100 tasks across 25 roles; each prompt has fill-in-the-blank fields you customize in the browser and copy in one click.
- Runs as a static site; nothing is uploaded.

Disclosure: I'm the author. Placed in Discoveries per the contribution guidelines (under the 1,000-star Main List bar). Entry follows the required format, ends with a period, no trailing whitespace.