### PR TITLE
Add Stop the Slop to Discoveries list

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -73,6 +73,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [AI Character for GPT](https://chromewebstore.google.com/detail/ai-character-for-gpt/daoeioifimkjegafelcaljboknjkkohh) - Easily customize AI chatbots like ChatGPT and Google Gemini for better responses.
 - [AI Summary Helper](https://chromewebstore.google.com/detail/ai-summary-helper-openai/hldbejcjaedipeegjcinmhejdndchkmb) - Get AI summaries of web content. Use Send To Kindle for reading on the go. [#opensource](https://github.com/philffm/ai-summary-helper)
 - [Chatgpt Light Session](https://chromewebstore.google.com/detail/fmomjhjnmgpknbabfpojgifokaibeoje) - A browser extension for trimming long ChatGPT conversations in the UI.
+- [Stop the Slop](https://github.com/MauroPello/stop-the-slop) - Detects whether YouTube video scripts are AI-generated in real-time with thumbnail badges and sentence heatmaps. [#opensource](https://github.com/MauroPello/stop-the-slop)
 
 ### Productivity
 


### PR DESCRIPTION
### Summary
Adds [Stop the Slop](https://github.com/MauroPello/stop-the-slop) to the **Discoveries list** under **ChatGPT extensions**.

**Stop the Slop** is a free, open-source (MIT) browser extension that detects whether YouTube video scripts are AI-generated by analyzing transcripts in real-time, featuring thumbnail badges and sentence heatmaps.