### PR TITLE
Add HelloGen to Discoveries - Video

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -228,6 +228,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [HelloGen](https://hellogen.ai/) - An AI image and video generator that picks a model for your request and quotes the price before rendering, with unlimited watermark-free images on the free tier.
 
 ### Avatars
 


### PR DESCRIPTION
Adding [HelloGen](https://hellogen.ai/) to the Discoveries list under Video.

**Entry:**
`- [HelloGen](https://hellogen.ai/) - An AI image and video generator that picks a model for your request and quotes the price before rendering, with unlimited watermark-free images on the free tier.`

**What it is:** a hosted studio that runs several image and video models (Seedream, Nano Banana, GPT Image 2, Veo, Kling, Seedance) behind one assistant. You describe the job in plain language; the assistant picks a model and shows the price before anything is rendered, and failed generations aren't charged. Image generation is unlimited and watermark-free on the free tier, with a commercial license on outputs.

**Checklist:**
- Format matches `[ProjectName](Link) - Description.`
- Added to the bottom of its category (Video)
- Description is one sentence and ends with a period
- No trailing whitespace
- Submitted to Discoveries rather than the Main List, since it does not yet meet the 1,000-follower criterion