### PR TITLE
Add OpenRoutiQ to Developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [OpenRoutiQ](https://github.com/antat-ai/openroutiq) - An open-source, explainable Python router that selects models, providers, deployments, and reasoning levels under quality, latency, cost, and policy constraints, with optional learning from trusted outcomes.
 
 ### Playgrounds
 


### PR DESCRIPTION
## Summary

Add OpenRoutiQ to Discoveries under Developer tools. OpenRoutiQ is an open-source, explainable Python router for selecting models, providers, deployments, and reasoning levels under quality, latency, cost, and policy constraints, with optional learning from trusted outcomes.

## Validation

- Added one entry at the bottom of the required category
- Confirmed there is no existing OpenRoutiQ entry, issue, or pull request
- Confirmed the repository link is public and accessible
- Ran git diff --check

## Disclosure

I maintain OpenRoutiQ through the antat-ai organization.