### PR TITLE
Add FutureOS to Autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [FutureOS](https://github.com/futuregene/future-os) - One AI agent everywhere you work: a single Rust backend drives a terminal UI, desktop app, mobile apps, CLI, and IM bots with the same sessions, memory, and skills. Trust-first approval-gated tools, 3,800+ models, and a loop control plane for 24h+ runs. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds [FutureOS](https://github.com/futuregene/future-os) to the **Agents → Autonomous agents** section.

FutureOS is one AI agent everywhere you work: a single Rust backend drives a terminal UI, desktop app, mobile apps, CLI, and IM bots with the same sessions, memory, and skills. Trust-first approval-gated tools, 3,800+ models across 140+ providers, and a built-in loop control plane for 24h+ runs. MIT + Apache-2.0.