### PR TITLE
Add Advibly to Discoveries (Video)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -228,6 +228,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [VideoGen](https://videogen.io/) - A video creation and editing platform with AI b-roll matching, narration, and captions.
 - [TubePrompter](https://tubeprompter.com/) - A tool that converts YouTube, TikTok, and Instagram videos into prompts for AI image and video generators.
 - [Glio](https://glio.io/) - A unified API for video, image, audio, and text generation models.
+- [Advibly](https://advibly.com/) - An ad-creative platform that generates on-brand image ads, UGC-style video ads, and talking-actor videos from brand and product context, in the app or from AI agents via MCP.
 
 ### Avatars
 


### PR DESCRIPTION
Adds [Advibly](https://advibly.com/) to the **Discoveries** list under **Video**, per the inclusion criteria (we don't yet claim the main list's 1,000-follower bar, so Discoveries is the right home).

Advibly generates finished advertising creative from brand and product context: on-brand image ads, UGC-style video ads, and talking-actor videos, plus carousels, voiceovers, and music. It's usable in the app or from AI agents via its remote MCP server ([docs](https://github.com/advibly/mcp)).

- Format follows the guidelines: `[ProjectName](Link) - Description.` with a closing period, appended to the bottom of the Video category.
- Actively maintained and documented; live product.

**Disclosure:** I'm affiliated with Advibly (co-founder); this PR was prepared with AI assistance.