### PR TITLE
Add StudyArena to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -101,6 +101,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 - [Price Per Token](https://pricepertoken.com/) - A tool for comparing LLM API pricing, token usage, and model benchmarks.
 - [Rival](https://rival.tips) - Leaderboard ranking 200+ AI models based on blind A/B human preference votes.
+- [StudyArena](https://studyarena.com) - Students compare three anonymous AI answers to one question, vote for the most useful response, then reveal the models.
 
 ### Other text generators
 


### PR DESCRIPTION
## Summary

Adds StudyArena to Discoveries under Text > Leaderboards.

I've been building StudyArena to help students compare AI answers before deciding which one is most useful. It presents three answers without model names, lets the student vote, and reveals the models afterward. Those votes also contribute to public model rankings.

I chose Discoveries because it is the documented home for useful newer generative AI projects.