### PR TITLE
Add Zero to AI-Native to Discoveries (Learning resources)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -284,6 +284,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Gemini by Example](https://geminibyexample.com) - A hands-on introduction to the Gemini API and SDK through annotated code examples. [#opensource](https://github.com/strickvl/geminibyexample)
 - [Rearchitecting LLMs](https://www.manning.com/books/rearchitecting-llms) - A book about optimizing and restructuring LLMs for domain-specific use.
 - [PromptZone](https://promptzone.com/) - Community and publication for prompt engineering, LLM comparisons, and AI-tool workflows.
+- [Zero to AI-Native](https://www.zerotoainative.xyz/) - An open-source, sequenced curriculum of primary-source AI reads across eight modules, from foundations through prompting, agents, evals, production, and safety.
 
 ## More lists
 


### PR DESCRIPTION
Adds Zero to AI-Native to the Discoveries list, Learning resources section (doesn't yet meet the 1,000-follower Main List bar, so Discoveries per the contribution guidelines).

It's an open-source, sequenced curriculum (https://www.zerotoainative.xyz) covering foundations through prompting, retrieval, agents, evals, production, and safety, with every catalog entry linking to the original lab, author, or institution. I'm the maintainer.

Repo: https://github.com/tushaarmehtaa/zero-to-ai-native