### PR TITLE
Add RizzMaster to Discoveries (Chatbots)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -41,6 +41,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GPTHelp.ai](https://gpthelp.ai/) - AI customer support chatbot for your website.
 - [AnythingLLM](https://anythingllm.com/) - Turn any document, resource, or piece of content into context that any LLM can use. [#opensource](https://github.com/Mintplex-Labs/anything-llm)
 - [Character AI Bots](https://www.characteraibots.com/) - A directory of free AI roleplay characters available on Character.AI, JanitorAI, and SpicyChat.
+- [RizzMaster](https://rizzmaster.net) - AI dating simulator for iOS: swipe, match, and text characters with persistent memory while a relationship meter moves on every message, and characters can ghost or block you.
 
 ### Custom interfaces
 


### PR DESCRIPTION
Adds RizzMaster to the Discoveries list under Text > Chatbots, at the bottom of the category, per the contribution guidelines.

RizzMaster is an AI dating simulator for iOS: you swipe and match with characters, then text them while a relationship meter moves on every message across nine levels. Characters keep persistent memory and bring earlier details up on their own, and they can ghost or permanently block you. Free tier with a daily message limit, premium subscription lifts it. Actively maintained, current version shipped July 2026.

Disclosure: I build RizzMaster. Submitting to Discoveries rather than the main list since it does not yet meet the 1,000-follower bar.