### PR TITLE
Add ModelBenchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenRouter LLM Rankings](https://openrouter.ai/rankings) - Language models ranked and analyzed by usage across apps.
 - [SEAL LLM Leaderboard](https://labs.scale.com/leaderboard) - Expert-driven LLM benchmarks and updated AI model leaderboards.
 - [LLM Stats](https://llm-stats.com/) - Compare AI models across benchmarks, pricing, speed, and context window.
+- [ModelBenchmark](https://modelbenchmark.io) - Specs, prices, benchmarks and lifecycle for 2,000+ AI models.
 
 ### Other text generators
 


### PR DESCRIPTION
Adds ModelBenchmark — a directory of AI model specs, pricing, benchmarks, and lifecycle data.

Placement: near similar model comparison / pricing / leaderboard links.