### PR TITLE
Add XYZZY to Discoveries (Agents)

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -176,6 +176,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GhostClaw](https://ghostclaw.io) - A local AI agent with full system access, controllable via Telegram. [#opensource](https://github.com/b1rdmania/ghostclaw)
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 - [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
+- [XYZZY](https://github.com/Project-Nexus-YR/XYZZY) - Self-hosted workspace where a team runs parallel specialist agents on one question, includes or excludes each output, and publishes a Decision Brief with every claim linked to its source. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
Submitted to the Discoveries list, at the bottom of Agents / Autonomous agents, in the [Name](Link) - Description. format with the #opensource tag, since the project does not yet meet the Main List's follower bar.

XYZZY is a self-hosted workspace where a small team branches a question into two or three parallel specialist agent runs, a person includes or excludes each output, and the included outputs become a Decision Brief whose claims link to the outputs that produced them. The event log is hash-chained with an audit command, and actions that change the room wait for human approval. One Python process on a single SQLite file, Docker image, works with Ollama, LM Studio or any OpenAI-compatible endpoint. Apache-2.0, 979 tests in CI, tagged v0.4.0.

Repo: https://github.com/Project-Nexus-YR/XYZZY
Live page: https://xyzzy.yasserameur-dev.workers.dev/

I am the author. Placed per the contributing guidelines; happy to adjust wording or section.