### PR TITLE
Add PixMind to image services discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -203,6 +203,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [deAPI.ai](https://deapi.ai/) - A unified inference API to open-source AI models for text-to-image, text-to-speech, transcription, video generation, and more, using a decentralized GPU cloud.
 - [MyPicNow](https://www.mypicnow.com) - An AI headshot generator for creating professional profile photos from uploaded selfies.
 - [PhotoMentor](https://photomentor.pro) - An AI tool for analyzing photos and providing composition and lighting feedback.
+- [PixMind](https://www.pixmind.io/) - Browser-based workspace for multi-model AI image and video generation, reference-image workflows, and natural-language editing.
 
 ### Graphic design
 


### PR DESCRIPTION
Add one concise PixMind entry at the bottom of the Image → Services section in `DISCOVERIES.md`, following the repository's required `[Project](Link) - Description.` format. The diff is one addition with no unrelated changes.

Disclosure: I work with PixMind. This is not an affiliate or paid placement; please review, edit, or reject it independently.