### PR TITLE
Add Higgs to Local LLM Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) - OpenAI-compatible local LLM inference server optimized for Apple Silicon, with tool calling, reasoning, vision, and structured output support. #opensource
 
 ## Agents
+- [Higgs](https://github.com/panbanda/higgs) - Rust inference server for Apple Silicon that runs MLX models behind OpenAI- and Anthropic-compatible APIs, with provider routing and a desktop dashboard. #opensource
 
 ### Autonomous agents
 


### PR DESCRIPTION
Higgs is a Rust inference server for Apple Silicon. It runs MLX models from Hugging Face behind OpenAI- and Anthropic-compatible HTTP APIs, routes requests to remote providers (OpenAI, Anthropic, Ollama) behind the same endpoint, and ships a terminal dashboard and a desktop app with per-request tracing. MIT licensed, installed with Homebrew, first released February 2026 and actively maintained.

Added at the bottom of Coding > Local LLM Deployment with the #opensource tag. Fine if it belongs in DISCOVERIES.md instead.