### PR TITLE
Add AI Talks to Discoveries learning resources

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -284,6 +284,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Gemini by Example](https://geminibyexample.com) - A hands-on introduction to the Gemini API and SDK through annotated code examples. [#opensource](https://github.com/strickvl/geminibyexample)
 - [Rearchitecting LLMs](https://www.manning.com/books/rearchitecting-llms) - A book about optimizing and restructuring LLMs for domain-specific use.
 - [PromptZone](https://promptzone.com/) - Community and publication for prompt engineering, LLM comparisons, and AI-tool workflows.
+- [AI Talks](https://aietalks.com/) - Searchable summaries and timestamped key ideas from AI Engineer YouTube talks about LLM applications and agents.
 
 ## More lists
 


### PR DESCRIPTION
Adds AI Talks to the Discoveries learning-resources section.

Disclosure: I maintain AI Talks, a free archive of searchable, timestamped AI Engineer talk summaries. I am proposing it for Discoveries, not the main list, in line with the repository's criteria.
