### PR TITLE
Add Awesome AI Agent Platforms to More lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Awesome Music AI](https://github.com/steven2358/awesome-music-ai) - A curated list of AI tools for music composition, generation, and analysis.
 - [Awesome AI Market Maps](https://github.com/joylarkin/Awesome-AI-Market-Maps) - A curated list of AI market maps from 2026, 2025, and 2024, by [Joy Larkin](https://twitter.com/joy).
 - [Awesome RAG Production](https://github.com/Yigtwxx/Awesome-RAG-Production) - A curated list of tools and resources for building production RAG systems.
+- [Awesome AI Agent Platforms](https://github.com/Agenta-AI/awesome-ai-agent-platforms#readme) - A curated list of open-source AI agent platforms: AI coworkers, agent builders and frameworks, workflow automation, browser agents, and coding agents.
 
 ### Lists on ChatGPT
 


### PR DESCRIPTION
This adds one entry to the More lists section: Awesome AI Agent Platforms, a curated list of open-source and source-available AI agent platforms grouped into AI coworkers, agent builders and frameworks, workflow automation, browser agents, and coding agents. Each entry states its license and hosting model.

List: https://github.com/Agenta-AI/awesome-ai-agent-platforms

It fits the More lists section as a sibling curated list. The bullet follows the existing format and is appended at the end of the general More lists items. Thanks for maintaining this list.