### PR TITLE
Add Agentique to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -295,5 +295,6 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Awesome AI Software Development Agents](https://github.com/flatlogic/awesome-ai-software-development-agents) - Curated list of AI agents designed for software development tasks.
 - [MODELDROP](https://modeldrop.fyi/) - A community tracker for new generative media AI model releases.
 - [MyVibe](https://www.myvibe.so) - A feed for discovering and sharing AI-created web apps, demos, and interactive projects.
+- [Agentique](https://agentique.ch) - A daily feed of AI news from 150+ sources, scored, categorized and tagged by an LLM pipeline.
 
 ### Lists on ChatGPT


### PR DESCRIPTION
Adds [Agentique](https://agentique.ch) to the More lists section of DISCOVERIES.md.

Agentique is a daily AI news feed. Articles from 150+ sources run through an LLM pipeline that deduplicates, scores for relevance and actionability, then categorizes and tags each piece.

