### PR TITLE
docs: add XiuAI platform deployment services to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -268,6 +268,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [KeepRule](https://keeprule.com) - Investment-discipline tool with curated principles from 26 investors and AI prompts for scenario analysis.
 - [GEOScore AI](https://geoscoreai.com/) - Free AI search visibility scanner that checks 11 GEO signals for ChatGPT, Perplexity, and Gemini visibility.
 - [DeepDNA](https://deepdna.ai) - AI-powered DNA analysis platform for personalized health, nutrition, and pharmacogenomic insights from consumer genetic data.
+- [XiuAI](https://xiu.ai/) - XiuAI builds practical AI products and services, including XiuRouter for multi-model API access and XiuStore for AI subscriptions and digital services.
 
 ## Learning resources
 


### PR DESCRIPTION
Adds XiuAI to Discoveries for its deployment and model-integration services: teams can run AI platforms and branded XiuStore/XiuRouter services in their own environments, with ongoing technical support.

The entry links the company website and [the current service description in Chinese](https://xiu.ai/zh/enterprise). The latter explicitly describes customer-held brands, domains, servers and business data, plus deployment, integration and support. The English `/en/enterprise` path currently redirects to the homepage, so it is not presented as an English service page.

Validation: one XiuAI line in `DISCOVERIES.md`; the current contribution format and final period are preserved, other entries are unchanged, and both public sources were read back. No prices, customer counts, benchmarks or open-source status are claimed.

Disclosure: submitted on behalf of XiuAI / XiuLab Inc with AI assistance. This remains the original XiuAI PR and is separate from the existing XiuRouter API listing.
