### PR TITLE
Add H3 Max Video Workbook to Discoveries learning resources

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -284,6 +284,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Gemini by Example](https://geminibyexample.com) - A hands-on introduction to the Gemini API and SDK through annotated code examples. [#opensource](https://github.com/strickvl/geminibyexample)
 - [Rearchitecting LLMs](https://www.manning.com/books/rearchitecting-llms) - A book about optimizing and restructuring LLMs for domain-specific use.
 - [PromptZone](https://promptzone.com/) - Community and publication for prompt engineering, LLM comparisons, and AI-tool workflows.
+- [H3 Max Video Workbook](https://github.com/lpg-it/h3-max-video-workbook) - Prompt briefs, input-selection guidance, and a comparison worksheet for short AI videos with audio.
 
 ## More lists
 


### PR DESCRIPTION
Adds H3 Max Video Workbook at the bottom of Learning resources in DISCOVERIES.md. The public workbook includes input-selection guidance, six prompt briefs, a comparison worksheet, and troubleshooting notes for short AI videos with audio.

Submitting on behalf of the workbook author and H3 Max Studio owner. The workbook is free to read; the associated studio is an independent paid application using MiniMax H3 Max through fal, not an official MiniMax, Hailuo, or fal product. This is a documentation resource, not application source code or model weights. The prompt cards are starting briefs, not tested benchmarks or guaranteed results.

Checked the current Discoveries list and existing pull requests for duplicates. Reviewed the final diff: one new entry in DISCOVERIES.md, one addition, zero deletions.