### PR TITLE
Add Kavel

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Reve Image](https://reve.com/) - A model trained from the ground up to excel at prompt adherence, aesthetics, and typography.
 - [Magnific](https://www.magnific.com/) - AI-powered design tools including image generation, background removal, and creative templates.
 - [FigureLabs](https://www.figurelabs.ai/) - An AI tool for generating publication-ready scientific figures in vector format from text descriptions or sketches.
+- [Kavel](https://www.kavel.ai/) - AI image and video studio with a per-edit page for each job — hairstyle, outfit, expression, background — and a free tier that runs without an account.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds [Kavel](https://www.kavel.ai/) under **Services**.

An AI image and video studio. What makes it different from the other entries in this section is the shape rather than the model: instead of one prompt box, it keeps a separate page per job — hairstyle, outfit swap, expression, background, aging — each preloaded with a prompt that works for that edit, which is the part people usually have to discover by trial.

There is a free tier that runs without an account, so the link is testable without signing up.