### PR TITLE
Add modelfax to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -150,6 +150,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [EvoLink](https://evolink.ai/) - API gateway providing unified access to 40+ AI models for chat, image, video, and music generation.
 - [shekel](https://github.com/arieradle/shekel) - A Python library that sets runtime spending limits for AI agents to prevent runaway LLM costs. #opensource
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
+- [modelfax](https://github.com/bytebrujo/modelfax) - A registry of AI model pricing, context windows, and deprecation and retirement dates, published as a static site and a schema-validated JSON API. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds `modelfax` to **Coding → Developer tools** in `DISCOVERIES.md`, at the bottom of the category.

Submitting to Discoveries rather than the main list deliberately: the project is new and does not meet the 1,000-follower bar in the contributing guide.

**What it is.** A registry of AI model pricing, context windows, and lifecycle dates across OpenAI, Anthropic and Google. The list already has [Price Per Token](https://pricepertoken.com/) for price comparison; the part this adds is the lifecycle half, deprecation and retirement dates, which is what tells you when a model you depend on stops answering.

- Site: https://bytebrujo.github.io/modelfax/
- The API is the data itself, static JSON with open CORS and no key: `https://bytebrujo.github.io/modelfax/data/anthropic.json`
- Every record validates against a published JSON Schema and cites the provider page it was read from, with the date it was last verified.
- Scrapers re-read the provider docs daily and open a pull request when something changes, so `git log -- data/` is the price history.

MIT code, CC-BY-4.0 data.