### PR TITLE
Add LLM Pulse to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -268,6 +268,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [KeepRule](https://keeprule.com) - Investment-discipline tool with curated principles from 26 investors and AI prompts for scenario analysis.
 - [GEOScore AI](https://geoscoreai.com/) - Free AI search visibility scanner that checks 11 GEO signals for ChatGPT, Perplexity, and Gemini visibility.
 - [DeepDNA](https://deepdna.ai) - AI-powered DNA analysis platform for personalized health, nutrition, and pharmacogenomic insights from consumer genetic data.
+- [LLM Pulse](https://llmpulse.ai/) - Tracks brand mentions, citations, sentiment, and competitor share of voice across AI search engines.
 
 ## Learning resources
 


### PR DESCRIPTION
Adds LLM Pulse to the Other section in DISCOVERIES.md.

LLM Pulse tracks brand mentions, citations, sentiment, and competitor share of voice across AI search engines. This sits directly alongside GEOScore AI in the existing discoveries list.

Canonical site: https://llmpulse.ai/

Disclosure: I am a co-founder of LLM Pulse.