### PR TITLE
Add ENZO to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -183,6 +183,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Ebiose](https://github.com/ebiose-ai/ebiose) - An open-source framework for creating and evolving AI agents through iterative selection. #opensource
 - [OpenPaw](https://github.com/daxaur/openpaw) - A CLI tool that turns Claude Code into a personal assistant with skills for email, calendar, Spotify, smart home, and Slack. #opensource
 - [AnveVoice](https://anvevoice.app) - Voice AI assistant for websites that takes real DOM actions, navigating pages, filling forms, and clicking buttons in 50+ languages.
+- [ENZO](https://github.com/theguysudo/ENZO) - Self-hosted AI workspace with agents, skills, and tools (Gmail, Calendar) that runs entirely on your own provider API keys (BYOK). #opensource
 
 ## Image
 


### PR DESCRIPTION
Adds **ENZO** to the Discoveries list (Agents → Custom assistants).

ENZO is a self-hosted AI workspace (Apache-2.0) with agents, skills, and tools — e.g. *"scan my unread Gmail and draft replies"* or *"find a slot on my Calendar next week"*. It runs entirely on the user's own provider API keys (OpenRouter, Groq, Gemini, NVIDIA…), self-hosted via a Docker one-liner (`ghcr.io/theguysudo/enzo`) or Node.js.

The project is young, so per the contribution guidelines it targets the **Discoveries** list rather than the Main List (it does not yet meet the 1,000-follower criterion).

- Repo: https://github.com/theguysudo/ENZO
- Live demo: https://enzo-hub.duckdns.org

Entry follows the `[ProjectName](Link) - Description.` format and is added to the bottom of the Custom assistants category.