### PR TITLE
Add Wikiprompt to Image libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenArt](https://openart.ai/) - Search 10M+ of prompts, and generate AI art via Stable Diffusion, DALL·E 2.
 - [PromptHero](https://prompthero.com/) - Search prompts for models like Stable Diffusion, ChatGPT, Midjourney, etc.
 - [PromptBase](https://promptbase.com/) - Search prompts from top prompt engineers. Sell your own prompts.
+- [Wikiprompt](https://www.wikiprompt.org/) - Open, Wikipedia-style encyclopedia of 100,000+ attributed AI prompts with their results, downloadable as an open dataset.
 
 ### Model libraries
 


### PR DESCRIPTION
Adds Wikiprompt (https://www.wikiprompt.org/), an open (CC BY-SA metadata) Wikipedia-style encyclopedia of 100,000+ AI prompts. Each prompt is attributed to its original author or source dataset, carries structured metadata (model, type, quality) and shows the generated result; the whole catalog is downloadable as an open dataset. Placed in Image libraries next to comparable prompt libraries.