### PR TITLE
Add Veida to Image / Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Reve Image](https://reve.com/) - A model trained from the ground up to excel at prompt adherence, aesthetics, and typography.
 - [Magnific](https://www.magnific.com/) - AI-powered design tools including image generation, background removal, and creative templates.
 - [FigureLabs](https://www.figurelabs.ai/) - An AI tool for generating publication-ready scientific figures in vector format from text descriptions or sketches.
+- [Veida](https://veida.ai/) - Text-to-image generator with a free tier that runs without an account or API key.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds Veida to the Image → Services list.

Text-to-image generator whose free tier runs without an account or API key. Follows the format of the surrounding entries.
