### PR TITLE
Add Atomic Mail (email for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [Atomic Mail](https://atomicmail.ai) - Email infrastructure for AI agents, providing autonomous inboxes via proof-of-work with a JMAP API and MCP server.
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds **Atomic Mail** ([atomicmail.ai](https://atomicmail.ai)) to the `Agents › Autonomous agents` section — a direct peer to the already-listed **AgentMail**, using the same one-line format and placed at the bottom of the category per CONTRIBUTING.md.

It's email infrastructure for AI agents: an agent gets its own inbox in ~30s via proof-of-work (no signup or key), with a JMAP API and an MCP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)