### PR TITLE
Add ModelRush to Discoveries developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -153,6 +153,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
 - [XVARY Stock Research](https://github.com/xvary-research/claude-code-stock-analysis-skill) - Claude Code skill for public equity research using SEC EDGAR and market data: thesis scoring, comparables, staleness rules. #opensource
 - [CPS Framework](https://github.com/citedbyai/cps-framework) - AI-citation-readiness scoring for web content, with a free MCP checker and paid full audits.
+- [ModelRush](https://modelrush.ai/) - An OpenAI-compatible API platform for text, image, video, and audio generation.
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds ModelRush to the bottom of the Developer tools section in DISCOVERIES.md, following the contribution format. ModelRush is a commercial OpenAI-compatible API service for text, image, video, and audio generation; this entry does not claim that the service is open source. Homepage: https://modelrush.ai/ . API documentation: https://modelrush.ai/docs . The homepage was checked and returned HTTP 200. I am submitting on behalf of ModelRush and am affiliated with the project. I am proposing the Discoveries list, not claiming that the service meets the Main List follower threshold. Happy to adjust or withdraw if it does not fit the list.