### PR TITLE
Add Autorec

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Loopin AI](https://www.loopinhq.com/) - Loopin is a collaborative meeting workspace that not only enables you to record, transcribe & summaries meetings using AI, but also enables you to auto-organise meeting notes on top of your calendar.
 - [Read AI](https://www.read.ai/) - An AI copilot for wherever you work, making your meetings, emails, and messages more productive with summaries, content discovery, and recommendations.
 - [Fireflies.ai](https://fireflies.ai) - Transcribe, summarize, search, and analyze all your team conversations.
+- [Autorec](https://autorec.app/) - Desktop app that detects Zoom, Teams and Google Meet calls, records them locally and transcribes them on-device, with optional summaries from any OpenAI-compatible endpoint.
 
 ### Academia
 


### PR DESCRIPTION
[Autorec](https://autorec.app/) belongs in Meeting assistants alongside Otter, Fireflies and Read AI, but it is the local one: a C++ desktop app that detects the call from the running processes and window titles instead of joining it as a bot, records to MP4 on disk, transcribes with whisper.cpp on the user's own CPU or GPU, and only calls out to an LLM if the user configures an OpenAI-compatible endpoint (including a local Ollama or LM Studio).

Linux, Windows and macOS. Appended to the end of `### Meeting assistants`.