### PR TITLE
Add PromptSpace to Discoveries → Image libraries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -217,6 +217,8 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 ### Image libraries
 
+- [PromptSpace](https://www.promptspace.in) - Free library of 5,000+ curated AI image prompts for Midjourney, DALL-E, FLUX, and Stable Diffusion, organized by style and use case. No signup required.
+
 ### Model libraries
 
 ### Stable Diffusion resources


### PR DESCRIPTION
## What

Adds [PromptSpace](https://www.promptspace.in) to `DISCOVERIES.md` under `### Image libraries` (currently an empty subsection).

## Entry

```
- [PromptSpace](https://www.promptspace.in) - Free library of 5,000+ curated AI image prompts for Midjourney, DALL-E, FLUX, and Stable Diffusion, organized by style and use case. No signup required.
```

## Why Discoveries (not Main List)

Per `CONTRIBUTING.md`, the Main List requires 1,000+ followers or existing maintainer interest. PromptSpace is newer and is submitted to the Discoveries list per the intended flow. Happy to be considered for the Main List later once it meets the follower threshold.

## Why this belongs in the list

- **Fills the "Image libraries" subsection** — currently empty; PromptSpace's flagship offering is 2,000+ Midjourney/DALL-E/FLUX/SD image prompts organized by style and use case, which is a direct fit.
- **Broad model coverage** — SD, Midjourney, DALL-E 3, FLUX, and Google Imagen all covered with tested prompts.
- **Free and no signup** — no paywall, no watermark, no credit card, no free-trial-then-charge model.
- **Actively maintained** — prompts refreshed when underlying models update (e.g., Midjourney V8 rollout in 2026).

## Notes

- Single-line entry, no other property links.
- I'm the maintainer ([@Shahrukh-10](https://github.com/Shahrukh-10)) — happy to adjust wording if you'd prefer.
