### PR TITLE
Add ContextStream to Discoveries developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -153,6 +153,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
 - [XVARY Stock Research](https://github.com/xvary-research/claude-code-stock-analysis-skill) - Claude Code skill for public equity research using SEC EDGAR and market data: thesis scoring, comparables, staleness rules. #opensource
 - [CPS Framework](https://github.com/citedbyai/cps-framework) - AI-citation-readiness scoring for web content, with a free MCP checker and paid full audits.
+- [ContextStream](https://contextstream.io) - Shared project context for Cursor, Claude Code, Codex, Grok, and the rest. Intelligence isn’t the bottleneck. Context is. [#opensource](https://github.com/contextstream/mcp-server)
 
 ### Playgrounds
 


### PR DESCRIPTION
## Summary

Adds [ContextStream](https://contextstream.io) to Discoveries → Coding → Developer tools.

ContextStream is shared project context for Cursor, Claude Code, Codex, Grok, and the rest. Intelligence isn’t the bottleneck. Context is.

- Site: https://contextstream.io
- Remote MCP: https://mcp.contextstream.io/mcp
- Benchmarks: https://contextstream.io/benchmarks
- Open source MCP server: https://github.com/contextstream/mcp-server

I filed this on Discoveries rather than the main list. The MCP server repo is under the 1,000-follower bar in CONTRIBUTING, and Discoveries is the path for that case.

Disclosure: I work on ContextStream.