### PR TITLE
Add Imaginode to Image / Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Reve Image](https://reve.com/) - A model trained from the ground up to excel at prompt adherence, aesthetics, and typography.
 - [Magnific](https://www.magnific.com/) - AI-powered design tools including image generation, background removal, and creative templates.
 - [FigureLabs](https://www.figurelabs.ai/) - An AI tool for generating publication-ready scientific figures in vector format from text descriptions or sketches.
+- [Imaginode](https://imaginode.ai/) - A node canvas that connects image, video, text, and voice models on a single credit balance, with the cost of each step shown before it runs.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds Imaginode at the bottom of **Image → Services**, following the guidelines: `[ProjectName](Link) - Description.`, added to the bottom of its category, description concise and ending with a period. Not open source, so no #opensource tag.

Imaginode is a node canvas where image, video, text, and voice models are wired together in one workspace and draw on the same credit balance. Each node shows its exact credit cost before it runs, and a failed generation is refunded automatically.

Disclosure: opened by an agent on behalf of the maintainer of the listed project.