### PR TITLE
Add Reactive Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [Reactive Agents](https://github.com/tylerjrbuell/reactive-agents-ts) - An open-source TypeScript agent framework that runs the same agent code on a local Ollama model or a frontier API, with tool-call healing, output verification, and a per-run evidence receipt. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
Adding [Reactive Agents](https://github.com/tylerjrbuell/reactive-agents-ts) to **Agents > Autonomous agents**.

An open-source (MIT) TypeScript agent framework built on Effect-TS. Its focus is running the *same* agent code reliably across model tiers — a local Ollama model (4B+) through to frontier APIs — via tool-call healing, output verification, and a per-run evidence receipt describing how each answer was produced. MCP-native, A2A multi-agent, 8 reasoning strategies.

Currently v0.16.0, 34 packages on npm, actively maintained. Docs: https://docs.reactiveagents.dev

Happy to adjust wording or placement.