### PR TITLE
Add Vivify GPT Image 2.5 to image services discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -207,6 +207,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [deAPI.ai](https://deapi.ai/) - A unified inference API to open-source AI models for text-to-image, text-to-speech, transcription, video generation, and more, using a decentralized GPU cloud.
 - [MyPicNow](https://www.mypicnow.com) - An AI headshot generator for creating professional profile photos from uploaded selfies.
 - [PhotoMentor](https://photomentor.pro) - An AI tool for analyzing photos and providing composition and lighting feedback.
+- [Vivify GPT Image 2.5](https://vivify.video/models/gpt-image-2-5) - Credit-based browser service for GPT Image 2.5 image generation and reference editing, with reusable example prompts.
 
 ### Graphic design
 


### PR DESCRIPTION
Adds one service to the end of Image → Services in DISCOVERIES.md.

Tool page: https://vivify.video/models/gpt-image-2-5

I am part of the Vivify product team. This is a self-submission to Discoveries; I am not claiming that the service meets the main list's follower threshold.

Vivify offers a browser interface for text-to-image generation and reference-guided editing with GPT Image 2.5. The linked page includes Flare / Sunburst controls, real before-and-after examples, and reusable prompts. It is a credit-based service with paid plans, requires an account for generation, and shows the credit quote before submission. It is not an official OpenAI product.

I checked README.md, DISCOVERIES.md, and existing issues/PRs for Vivify duplicates. The change adds only this service, uses the requested link-description format, and ends with a period. The page is publicly accessible; no free/unlimited-use or quality-ranking claim is made.