### PR TITLE
Add ToHuman to Writing assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Postwise](https://postwise.ai/) - Write tweets, schedule posts and grow your following using AI.
 - [Copysmith](https://copysmith.ai/) - AI content creation solution for Enterprise & eCommerce.
 - [Humanize-Text](https://github.com/lynote-ai/humanize-text) - AI text humanizer with a multilingual rewriting pipeline and step-by-step examples. #opensource
+- [ToHuman](https://tohuman.io) - Rewrites AI-assisted drafts so they read like your own writing, with adjustable intensity and an API.
 
 ### ChatGPT extensions
 


### PR DESCRIPTION
Adds ToHuman at the bottom of Text → Writing assistants: a hosted tool (web app + REST API + MCP endpoint) that rewrites AI-assisted drafts so they read like your own writing, with adjustable intensity. Free tier, no card.

Disclosure: I'm on the ToHuman team. Fine with the Discoveries list if it doesn't meet the main-list bar.
