### PR TITLE
Add Milo to Discoveries / Chatbots

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -41,6 +41,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [GPTHelp.ai](https://gpthelp.ai/) - AI customer support chatbot for your website.
 - [AnythingLLM](https://anythingllm.com/) - Turn any document, resource, or piece of content into context that any LLM can use. [#opensource](https://github.com/Mintplex-Labs/anything-llm)
 - [Character AI Bots](https://www.characteraibots.com/) - A directory of free AI roleplay characters available on Character.AI, JanitorAI, and SpicyChat.
+- [Milo](https://milo.seemplifyai.com/) - Browser voice companion with an animated 3D robot, local or optional ChatGPT replies, and speech playback; free for personal, noncommercial use.
 
 ### Custom interfaces
 


### PR DESCRIPTION
Adds [Milo](https://github.com/michaelegbo/milo) to **Chatbots**.

A newly launched, working voice companion with an expressive procedural avatar. The Discoveries list explicitly welcomes emerging projects; this does not request the established-project main list.

Demo: https://milo.seemplifyai.com/

Milo uses on-device Whisper transcription and local Qwen replies. Hosted speech sends output text through Milo to a voice provider, with local Kokoro as fallback; optional ChatGPT sends messages and context through Milo to OpenAI. Source is available under PolyForm Noncommercial 1.0.0, not an OSI open-source license.

Affiliation: this is a submission by the Milo project owner, prepared with AI assistance. No sponsorship or paid placement is requested.

Validation: reviewed the destination section and contribution instructions, checked for duplicates, and verified the source and demo links. One listing addition; no unrelated changes.