### PR TITLE
Add YYLO to Discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -180,6 +180,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [Fazm](https://fazm.ai) - A native macOS app that runs Claude Code and Codex agents with persistent sessions, and can control the browser and other Mac apps. [#opensource](https://github.com/m13v/fazm)
 - [Network-AI](https://github.com/Jovancoding/Network-AI) - A TypeScript/Node.js multi-agent orchestrator with shared state, guardrails, token budgets, and adapters for multiple agent frameworks. #opensource
 - [Agency Orchestrator](https://github.com/jnMetaCode/agency-orchestrator) - YAML-first multi-agent workflow orchestrator with built-in AI roles, DAG parallelism, and conditional branching. Supports DeepSeek, Claude, OpenAI, and Ollama. #opensource
+- [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator for AI coding agents with typed task, validation, merge, and release-readiness boundaries across parallel worktrees. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
## Summary

Adds **YYLO** to the **Autonomous agents** section of the Discoveries list, at the bottom of the category (per the contribution guidelines).

- Repo: https://github.com/yylo-dev/yylo (MIT)

YYLO is a command-line orchestrator for AI coding agents: each task gets its own branch and git worktree, coding agents (Pi, Codex, and others) do the work, and a typed merge queue owns validation and release-readiness. Placed alongside Maestro and Agency Orchestrator as the coding-agent family's orchestration layer.

Submitting to Discoveries since the project does not yet meet the main-list criteria (1,000 followers). For context: MIT-licensed, ~8 months of daily development, 58 GitHub stars, and ~780 npm downloads/month for `@yylo/cli`.

## Changes

- `DISCOVERIES.md`: +1 line, no other edits.

## Disclosure

I'm on the team that builds YYLO, and this PR was prepared with the help of an AI coding agent (our normal workflow). Happy to adjust the entry line or move it to a better-fitting section (e.g. Coding → Developer tools) if you'd prefer.
