### PR TITLE
Add ResumeAI under Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 
 ### Productivity
 
+- [ResumeAI](https://withresumeai.com/) - AI resume builder with a free ATS checker (3/day no account, 10/day free account) and open State of ATS 2026 data.
 - [ChatPDF](https://www.chatpdf.com/) - Chat with any PDF.
 - [Mem](https://mem.ai/) - Mem is the world's first AI-powered workspace that's personalized to you. Amplify your creativity, automate the mundane, and stay organized automatically.
 - [Taskade](https://www.taskade.com/) - Outline tasks, notes, generated structured lists and mind maps with Taskade AI.


### PR DESCRIPTION
## Why
Adds [ResumeAI](https://withresumeai.com/) — an AI resume builder with a **free ATS checker** (3/day with no account, 10/day with a free account).

Also relevant: open [State of ATS 2026](https://github.com/Kayvan-Zahiri/state-of-ats-2026) dataset (738 employers, 704 portal-verified; Workday share **37.9%**).

## Notes
- Domain is withresumeai.com (not resume.ai)
- Focused one-line add matching list style
- Happy to adjust wording/placement

— Kayvan Zahiri · kayvan@withresumeai.com