### PR TITLE
Add Astell to Discoveries › Productivity

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -85,6 +85,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [SageCollab](https://sagecollab.com/) - SageCollab brings team collaboration features to generative AI.
 - [Worksheets.ai](https://www.worksheets.ai/) - Generate educational worksheets and lesson plans with AI.
 - [Recall](https://www.recall.it/) - A self-organizing knowledge base, where you can summarize and chat with any online content.
+- [Astell](https://astell.ai) - Company memory for small teams: reads Slack, Gmail, Linear, Notion, Drive and GitHub and surfaces dropped follow-ups with sources.
 
 ### Meeting assistants
 - [Goelo](https://www.goelo.com/) - Goelo helps sales teams automatically fill their CRM by recording meetings to create summaries and generate a knowledge base.


### PR DESCRIPTION
Adding Astell (https://astell.ai), a company-memory tool for 10–60 person teams. It reads Slack, Gmail, Google Drive, Google Calendar, Notion, Linear and GitHub, links decisions and owners across them, answers with the source, and surfaces follow-ups that went quiet.

Disclosure: I am the founder (Lab24, Boston). Happy to adjust wording or placement.

Submitted to the Discoveries list per the contribution guidelines (we do not yet meet the 1,000-follower bar for the main list).