### PR TITLE
Add Suno Style Recipes (CC0 dataset) to Audio > Music

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [AIVA](https://www.aiva.ai/) - AI-based music generation assistant. Choose from 250+ styles.
 - [Suno AI](https://suno.com/) - Anyone can make great music. No instrument needed, just imagination. From your mind to music.
 - [Udio](https://www.udio.com/) - Discover, create, and share music with the world.
+- [MUSAI](https://musaisong.app) - An AI songwriter that turns your story into original song lyrics, and gives you a genre-calibrated style prompt to generate the track in Suno or Udio, plus a numbered illustrated plate. 564 documented styles, English and Spanish.
 
 ## Other
 


### PR DESCRIPTION
This entry now points to **Suno Style Recipes**, a public domain (CC0) dataset of 564 music styles, instead of the paid tool it comes from. Each style carries a style prompt, BPM, and the Weirdness and Style Influence settings for Suno and Udio, as CSV, JSON and Parquet.

Format follows the guidelines: `[ProjectName](Link) - Description.`, bottom of the Music category, description ends with a period, `#opensource` because the data is public domain. If it fits the Discoveries list better than the main list, that works too.

(disclosure: I built and maintain it)