### PR TITLE
Add ContextStream to Coding → Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [ContextStream](https://contextstream.io) - Shared project memory / MCP for AI coding agents so Cursor, Claude, Codex, Grok, and others share context. [#opensource](https://github.com/contextstream/mcp-server)
 
 ### Playgrounds
 


### PR DESCRIPTION
## Summary
Add [ContextStream](https://contextstream.io) under **Coding → Developer tools** (after Bifrost, at the bottom of the category).

ContextStream is a shared project memory / MCP for AI coding agents so Cursor, Claude, Codex, Grok, and others share context across tools.

- Site: https://contextstream.io
- Benchmarks: https://contextstream.io/benchmarks
- Open-source MCP server: https://github.com/contextstream/mcp-server

## Format
`[ContextStream](https://contextstream.io) - Shared project memory / MCP for AI coding agents so Cursor, Claude, Codex, Grok, and others share context. [#opensource](https://github.com/contextstream/mcp-server)`

Thanks for maintaining this list!