### PR TITLE
Add Drevon

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Morpher AI](https://morpher.com/ai) - Morpher AI delivers real-time insights and analysis for any market.
 - [Whimsical AI](https://whimsical.com/ai) - GPT-powered mind mapping, flowcharts, and visual tools for rapid idea development and process organization.
 - [Selfies with Sama](https://selfies-with-sama.vost.ai) - Grab a picture with a real-life billionaire!
+- [Drevon](https://drevon.dev) - A console for GTM engineers where AI agents run evidence-backed prospecting, signal tracking, account research, and inbound qualification, using a native browser that works with your own LinkedIn, Sales Nav, and Twitter/X logins and connects the rest of your GTM stack over MCP, for individuals, teams, or self-hosted enterprise deployments.
 
 ## Learning resources
 


### PR DESCRIPTION
Adds [Drevon](https://drevon.dev) to the Other category.

Drevon is a console for GTM engineers: AI agents run evidence-backed prospecting, signal tracking, account research, and inbound qualification. It ships with a native browser that uses your own LinkedIn, Sales Nav, and Twitter/X logins, connects the rest of your GTM stack over MCP, and works for individuals, teams, or self-hosted enterprise deployments.

It didn't fit cleanly under Text, Coding, Agents, Image, Video, or Audio, so I placed it in Other alongside similar business/research-focused AI tools already listed there (FinChat, Morpher AI). Happy to move it if you'd prefer a different spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)