### PR TITLE
Add Modelglass to Discoveries / Other

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -274,6 +274,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [KeepRule](https://keeprule.com) - Investment-discipline tool with curated principles from 26 investors and AI prompts for scenario analysis.
 - [GEOScore AI](https://geoscoreai.com/) - Free AI search visibility scanner that checks 11 GEO signals for ChatGPT, Perplexity, and Gemini visibility.
 - [DeepDNA](https://deepdna.ai) - AI-powered DNA analysis platform for personalized health, nutrition, and pharmacogenomic insights from consumer genetic data.
+- [Modelglass](https://modelglass.com.au) - Sourced, versioned pricing and capability data for AI models across image, language, video and audio, with coding, science and agentic benchmark verticals, to find the cheapest model that clears a capability bar.
 
 ## Learning resources
 


### PR DESCRIPTION
Adds Modelglass to the Discoveries list under **Other**, alongside comparable entries like *GPU Per Hour* (cloud price comparison).

Modelglass is a pricing and capability comparison layer for AI models spanning image, language, video and audio, plus coding/science/agentic benchmark verticals — every price and benchmark score sourced and versioned. It's in public beta at modelglass.com.au with a free tier, so it lands on the Discoveries list rather than the main list.

One entry, appended to the bottom of the Other category.