### PR TITLE
Add ScribeToAny to Speech-to-text discoveries

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -251,6 +251,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 - [Typist](https://iamtypist.dev) - Fast audio transcription service powered by Whisper models hosted on Groq.
 - [Echo99](https://www.echo99.app/) - A private macOS call recorder with on-device transcription and speaker labeling.
+- [ScribeToAny](https://scribetoany.com) - Audio and video transcription platform with speaker diarization and translation.
 
 ### Music
 - [Boomy](https://boomy.com/) - Create original songs in seconds.


### PR DESCRIPTION
## Summary

Add ScribeToAny to the Speech-to-text section of the Discoveries list.

ScribeToAny is an AI-powered audio and video transcription platform with speaker diarization and translation into 99+ languages.

## Why it fits

- Fast and accurate speech-to-text transcription powered by Whisper.
- Built-in speaker diarization to identify and label different speakers.
- Multi-language translation support.
- Clean web interface with export options (SRT, VTT, TXT).

The Discoveries list is the appropriate destination under the contribution guidelines.

## Validation

- `git diff --check` passed with no whitespace errors.
- Confirmed the entry is added at the bottom of the Speech-to-text section.
- Confirmed the website https://scribetoany.com is live and operational.