### PR TITLE
Add OpenHuman to Autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [OpenHuman](https://github.com/tinyhumansai/openhuman) - Local-first AI desktop app for Mac, Windows and Linux that runs agents, workflows and MCP servers on your machine with local or cloud models. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
Adds OpenHuman to Agents > Autonomous agents. OpenHuman is an open-source (GPL-3.0) local-first AI desktop app for Mac, Windows and Linux: it runs agents, workflows and MCP servers on the user's machine, with local models via Ollama or LM Studio or any provider with the user's own key. The GitHub repo is well above the 1,000-follower threshold in CONTRIBUTING.md. I am on the team that builds it.