### PR TITLE
Add Webcmd to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Model Context Protocol](https://modelcontextprotocol.io/) - An open standard for connecting AI models to external tools and data sources. [MCP Registry](https://registry.modelcontextprotocol.io/) [#opensource](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - [Steel Browser](https://github.com/steel-dev/steel-browser) - An open-source browser sandbox and automation infrastructure for AI agents, with session management, screenshots, PDFs, proxies, and anti-bot tooling. #opensource
 - [Bifrost](https://github.com/maximhq/bifrost) - An open-source LLM gateway with routing, load balancing, guardrails, and observability for 1000+ models. #opensource
+- [Webcmd](https://github.com/agentrhq/webcmd) - Self-learning browser infrastructure that compiles a site's navigation into deterministic per-site CLI commands for AI agents. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds Webcmd to Developer tools, at the bottom of the category per the guidelines.

Webcmd is open-source (Apache-2.0, 1.5k+ stars) browser infrastructure for AI agents. It learns how a site is navigated once, then compiles that into deterministic per-site CLI commands so agents stop re-exploring pages on every run. Actively maintained; docs at https://webcmd.dev/docs.

Disclosure: I contribute to this project.