### PR TITLE
Add CitePod to Text-to-speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Bark](https://github.com/suno-ai/bark) - A transformer-based text-to-audio model. #opensource
 - [TTS WebUI](https://github.com/rsxdalv/TTS-WebUI) - Web UI for running multiple text-to-speech, music generation, and audio tools. #opensource
 
+- [CitePod](https://citepod.com/) - Turn study notes into an AI-generated study podcast with a transcript, topic coverage and recall questions.
+
 ### Speech-to-text
 
 - [Whisper](https://openai.com/index/whisper/) - Robust speech recognition via large-scale weak supervision. [#opensource](https://github.com/openai/whisper)


### PR DESCRIPTION
Adds [CitePod](https://citepod.com/) to the Text-to-speech section.

CitePod turns study notes into a short AI-generated study podcast, including a transcript, topic coverage check and source-linked recall questions.

Disclosure: I'm a contributor to the CitePod project.