### PR TITLE
Add berth to Developer tools

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -153,6 +153,7 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - A CLI that diffs an AI agent's behavior between two runs, showing changes in tool calls, arguments, cost, latency, and outcomes. #opensource
 - [XVARY Stock Research](https://github.com/xvary-research/claude-code-stock-analysis-skill) - Claude Code skill for public equity research using SEC EDGAR and market data: thesis scoring, comparables, staleness rules. #opensource
 - [CPS Framework](https://github.com/citedbyai/cps-framework) - AI-citation-readiness scoring for web content, with a free MCP checker and paid full audits.
+- [berth](https://github.com/Mrjwj34/berth) - Daemonless local workspaces for parallel coding agents: a Git worktree, a private data directory, reserved ports, and supervised processes per workspace. #opensource
 
 ### Playgrounds
 


### PR DESCRIPTION
Adds berth to the Discoveries list under Coding / Developer tools.

berth provisions a separate local workspace per task -- a linked Git worktree, a private data directory, reserved ports and supervised processes -- with no background daemon and no virtualization.

https://github.com/Mrjwj34/berth