### PR TITLE
Add Datasets section with AI Timeline Dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Video](#video)
 - [Audio](#audio)
 - [Other](#other)
+- [Datasets](#datasets)
 - [Learning resources](#learning-resources)
 - [More lists](#more-lists)
 
@@ -438,6 +439,10 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Morpher AI](https://morpher.com/ai) - Morpher AI delivers real-time insights and analysis for any market.
 - [Whimsical AI](https://whimsical.com/ai) - GPT-powered mind mapping, flowcharts, and visual tools for rapid idea development and process organization.
 - [Selfies with Sama](https://selfies-with-sama.vost.ai) - Grab a picture with a real-life billionaire!
+
+## Datasets
+
+- [AI Timeline Dataset](https://github.com/techa-ai/ai-timeline-dataset) - Open CC BY 4.0 dataset of 2,658 dated, source-linked AI events from July 2025 onward, covering models, chips, robotics, regulation and incidents. #opensource
 
 ## Learning resources
 


### PR DESCRIPTION
Adds a **Datasets** category with one entry.

**[AI Timeline Dataset](https://github.com/techa-ai/ai-timeline-dataset)** - an open, dated, source-linked record of 2,658 AI events from July 2025 onward. Every row carries the primary source URL it was extracted from, plus the realm (software / physical / space), the actor, and a materiality score.

Why a new category: there is currently no home in the list for data. The closest sections are Learning resources (courses and books) and Recommended reading (individual articles), and a dataset fits neither. The contributing guide says new categories are welcome, so I have proposed one rather than forcing the entry somewhere it does not belong. Happy to move it under an existing heading instead if you would prefer.

Against the quality standards:
- **Useful to the community** - it answers "when did this actually start" and "how has the mix shifted between software, robotics and space" without re-reading a year of headlines. CSV and JSON, loadable straight from a raw URL in one line of pandas.
- **Actively maintained** - it is generated from a live daily timeline and updates as that grows.
- **Well-documented** - full schema table, runnable quickstart, and an explicit caveats section covering coverage limits and the fact that `materiality` is model-assigned rather than validated.

Licensed CC BY 4.0. No source text is redistributed; the dataset links out to publishers rather than copying them.
