### PR TITLE
Add NanoAvatar to Discoveries avatars

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -237,6 +237,8 @@ Before submitting your suggestions, please review the [Contribution Guidelines](
 
 ### Avatars
 
+- [NanoAvatar](https://github.com/wpydcr/NanoAvatar) - Audio-driven talking avatars rendered locally on Android and NVIDIA GPUs, with streaming generation. #opensource
+
 ### Animation
 
 ## Audio


### PR DESCRIPTION
Adds NanoAvatar to **Avatars** in `DISCOVERIES.md`, following the contribution guidelines for emerging projects.

NanoAvatar renders talking-avatar video locally from audio. It includes Android and NVIDIA GPU inference source, downloadable model weights, and an Android demo whose Experience mode works offline without an API key.

I am the project author. Review links: [demo](https://github.com/wpydcr/NanoAvatar#demo), [Android releases](https://github.com/wpydcr/NanoAvatar/releases/latest), and [model weights](https://huggingface.co/wpydcr/NanoAvatar).

The entry follows the required format and ends with the source-code tag. NanoAvatar-authored source is MIT licensed; lip-sync weights are CC BY-NC 4.0. Checked the list and existing pull requests for duplicates.