### PR TITLE
Add VibeLeaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [Awesome Music AI](https://github.com/steven2358/awesome-music-ai) - A curated list of AI tools for music composition, generation, and analysis.
 - [Awesome AI Market Maps](https://github.com/joylarkin/Awesome-AI-Market-Maps) - A curated list of AI market maps from 2026, 2025, and 2024, by [Joy Larkin](https://twitter.com/joy).
 - [Awesome RAG Production](https://github.com/Yigtwxx/Awesome-RAG-Production) - A curated list of tools and resources for building production RAG systems.
+- [VibeLeaderboard](https://www.vibeleaderboard.ai) - Curated index of AI coding tools and vibe-coded apps with builder profiles and a daily cited brief.
 
 ### Lists on ChatGPT
 


### PR DESCRIPTION
Adds VibeLeaderboard to the bottom of the "More lists" category.

I maintain this project. VibeLeaderboard (https://www.vibeleaderboard.ai) is an editorially gated index of AI coding tools and vibe-coded apps, organized by capability, with builder profiles, a daily cited AI brief, and an MCP server for agents. It is free to use. It is not open source, so there is no #opensource tag.

Format follows CONTRIBUTING.md. awesome-lint reports no new findings for this line (84 before, 84 after). If it belongs in the Discoveries list rather than the main list, that is fine.
