### PR TITLE
Add Nexus-Agent to Autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Contributions to this list are welcome. Before submitting your suggestions, plea
 - [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). #opensource
 - [Dorothy](https://github.com/Charlie85270/Dorothy) - An open-source desktop app to orchestrate multiple AI CLI agents simultaneously with automations and Kanban management. #opensource
 - [Hive](https://github.com/aden-hive/hive) - An open-source multi-agent framework with auto-generated graphs, evolution loops, and MCP integration. #opensource
+- [Nexus-Agent](https://github.com/parkain707/nexus-agent) - An autonomous AI software engineering agent with self-healing ReAct loops, AST pre-validation, time-travel code rollback, and dual CLI & Web UI. #opensource
 
 ### Custom assistants
 


### PR DESCRIPTION
### Summary
Adds [Nexus-Agent](https://github.com/parkain707/nexus-agent) to the **Agents → Autonomous agents** section.

### About Nexus-Agent
- **License:** MIT (Open Source)
- **Highlights:** Autonomous AI software engineering agent featuring self-healing ReAct loops, AST pre-validation guardrails, persistent time-travel SQLite rollback, and dual Rich CLI & Web UI with live streaming.
- **Repository:** https://github.com/parkain707/nexus-agent
- **Live Demo:** https://should-busy-repairs-metres.trycloudflare.com

### Checklist
- [x] Follows repository formatting
- [x] Valid URL to active open-source project
- [x] Concise, objective description